### PR TITLE
Dockerize the application so we can run within Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM debian:stretch
+FROM debian:stable-slim
 
 RUN apt update && \
      apt install -y \
-     curl \
+     wget \
      && rm -rf /var/lib/apt/lists/*
 
-RUN curl -L -O https://github.com/wagoodman/dive/releases/download/v0.0.5/dive_0.0.5_linux_amd64.deb
+RUN wget https://github.com/wagoodman/dive/releases/download/v0.0.5/dive_0.0.5_linux_amd64.deb
 RUN apt install ./dive_0.0.5_linux_amd64.deb
 
 ENTRYPOINT ["dive"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM debian:stretch
+
+RUN apt update && \
+     apt install -y \
+     curl \
+     && rm -rf /var/lib/apt/lists/*
+
+RUN curl -L -O https://github.com/wagoodman/dive/releases/download/v0.0.5/dive_0.0.5_linux_amd64.deb
+RUN apt install ./dive_0.0.5_linux_amd64.deb
+
+ENTRYPOINT ["dive"]


### PR DESCRIPTION
Still need docker.sock from the host, and only tested on Mac OS X 10.13.6 with Docker version 18.06.1-ce, build e68fc7a.  Definitely need a lot more testing.

Test built using:

```
docker build . -t huanga/dive:0.0.5
```

Test execution using:

```
docker run --rm -it -v /var/run/docker.sock:/var/run/docker.sock \
    -v $(which docker):/bin/docker \
    huanga/dive:0.0.5 huanga/cfddns:0.0.1
```

Seems to work okay for analyze. 