### PR TITLE
Support version printout

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -21,12 +21,14 @@ func analyze(cmd *cobra.Command, args []string) {
 		}
 
 		fmt.Println("No image argument given")
+		cmd.Help()
 		os.Exit(1)
 	}
 
 	userImage := args[0]
 	if userImage == "" {
 		fmt.Println("No image argument given")
+		cmd.Help()
 		os.Exit(1)
 	}
 	color.New(color.Bold).Println("Analyzing Image")

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -2,16 +2,28 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 	"github.com/wagoodman/dive/image"
 	"github.com/wagoodman/dive/ui"
-	"os"
 )
 
 // analyze takes a docker image tag, digest, or id and displayes the
 // image analysis to the screen
 func analyze(cmd *cobra.Command, args []string) {
+	if len(args) == 0 {
+		printVersionFlag, err := cmd.PersistentFlags().GetBool("version")
+		if err == nil && printVersionFlag {
+			printVersion(cmd, args)
+			return
+		}
+
+		fmt.Println("No image argument given")
+		os.Exit(1)
+	}
+
 	userImage := args[0]
 	if userImage == "" {
 		fmt.Println("No image argument given")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,13 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/k0kubun/go-ansi"
 	"github.com/mitchellh/go-homedir"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/tebeka/atexit"
-	"os"
 )
 
 var cfgFile string
@@ -19,7 +20,7 @@ var rootCmd = &cobra.Command{
 	Short: "Docker Image Visualizer & Explorer",
 	Long: `This tool provides a way to discover and explore the contents of a docker image. Additionally the tool estimates
 the amount of wasted space and identifies the offending files from the image.`,
-	Args: cobra.ExactArgs(1),
+	Args: cobra.MaximumNArgs(1),
 	Run:  analyze,
 }
 
@@ -44,6 +45,8 @@ func init() {
 
 	// TODO: add config options
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.dive.yaml)")
+
+	rootCmd.PersistentFlags().BoolP("version", "v", false, "display version number")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+type Version struct {
+	Version   string
+	Commit    string
+	BuildTime string
+}
+
+var version *Version
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "print the version number and exit (also --version)",
+	Run:   printVersion,
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+func SetVersion(v *Version) {
+	version = v
+}
+
+func printVersion(cmd *cobra.Command, args []string) {
+	fmt.Printf("dive %s\n", version.Version)
+}

--- a/main.go
+++ b/main.go
@@ -20,9 +20,7 @@
 
 package main
 
-import (
-	"github.com/wagoodman/dive/cmd"
-)
+import "github.com/wagoodman/dive/cmd"
 
 var (
 	version   = "No version provided"
@@ -31,5 +29,11 @@ var (
 )
 
 func main() {
+	cmd.SetVersion(&cmd.Version{
+		Version:   version,
+		Commit:    commit,
+		BuildTime: buildTime,
+	})
+
 	cmd.Execute()
 }


### PR DESCRIPTION
Verified that this change works with GoReleaser.

```
> ./dist/darwin_amd64/dive -v
dive 0.0.6

> ./dist/darwin_amd64/dive --version
dive 0.0.6

> ./dist/darwin_amd64/dive version
dive 0.0.6
```

This fixes #32 