### PR TITLE
Support configuring the docker client from environment variables

### DIFF
--- a/image/image.go
+++ b/image/image.go
@@ -6,12 +6,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/sirupsen/logrus"
 
 	"github.com/docker/docker/client"
 	"github.com/wagoodman/dive/filetree"
@@ -201,7 +202,7 @@ func InitializeData(imageID string) ([]*Layer, []*filetree.FileTree, float64, fi
 
 	// pull the image if it does not exist
 	ctx := context.Background()
-	dockerClient, err := client.NewClientWithOpts(client.WithVersion(dockerVersion))
+	dockerClient, err := client.NewClientWithOpts(client.WithVersion(dockerVersion), client.FromEnv)
 	if err != nil {
 		fmt.Println("Could not connect to the Docker daemon:" + err.Error())
 		utils.Exit(1)
@@ -334,7 +335,7 @@ func InitializeData(imageID string) ([]*Layer, []*filetree.FileTree, float64, fi
 
 func saveImage(imageID string) (string, string) {
 	ctx := context.Background()
-	dockerClient, err := client.NewClientWithOpts(client.WithVersion(dockerVersion))
+	dockerClient, err := client.NewClientWithOpts(client.WithVersion(dockerVersion), client.FromEnv)
 	if err != nil {
 		fmt.Println("Could not connect to the Docker daemon:" + err.Error())
 		utils.Exit(1)


### PR DESCRIPTION
This allows users to set DOCKER_HOST and other configuration variables to be used by dive. With these changes, I can connect to the docker daemon on my windows machine (running on windows or linux mode) from the Windows Subsystem for Linux.

Fixes #29.