### PR TITLE
Use curl instead of wget on RHEL/CentOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ sudo apt install ./dive_0.3.0_linux_amd64.deb
 
 **RHEL/Centos**
 ```bash
-wget https://github.com/wagoodman/dive/releases/download/v0.3.0/dive_0.3.0_linux_amd64.rpm
+curl -OL https://github.com/wagoodman/dive/releases/download/v0.3.0/dive_0.3.0_linux_amd64.rpm
 rpm -i dive_0.3.0_linux_amd64.rpm
 ```
 


### PR DESCRIPTION
RHEL/CentOS don't include `wget` by default in their minimal install types, whereas `curl` is included in everything.  So, this PR updates the RHEL/CentOS instructions to use that instead. :smile: