### PR TITLE
Properly restore terminal cursor in some cases

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -27,6 +27,7 @@ func doBuild(cmd *cobra.Command, args []string) {
 	defer utils.Cleanup()
 	iidfile, err := ioutil.TempFile("/tmp", "dive.*.iid")
 	if err != nil {
+		utils.Cleanup()
 		log.Fatal(err)
 	}
 	defer os.Remove(iidfile.Name())
@@ -34,11 +35,13 @@ func doBuild(cmd *cobra.Command, args []string) {
 	allArgs := append([]string{"--iidfile", iidfile.Name()}, args...)
 	err = utils.RunDockerCmd("build", allArgs...)
 	if err != nil {
+		utils.Cleanup()
 		log.Fatal(err)
 	}
 
 	imageId, err := ioutil.ReadFile(iidfile.Name())
 	if err != nil {
+		utils.Cleanup()
 		log.Fatal(err)
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ func Execute() {
 		fmt.Println(err)
 		utils.Exit(1)
 	}
+	utils.Cleanup()
 }
 
 func init() {


### PR DESCRIPTION
Hello

I ran across this project and find it useful in many ways. Thank you for your work.

While using it, under certain circumstances, I noticed the terminal's cursor gone missing. After a few `reset` as workaround, I decided to take a closer look.

I noticed two distinct cases:
- when the UI is not initialized at all, like `dive -h` or `dive version`
- when invoked with some invalid arguments, like `dive build 1234567`, due to `log.Fatal` closing the program before restoring the terminal cursor.

Since I'm willing to learn Go, I've made a little pull request on the subject. It restores the cursor when the program exits normally without UI instanciation, or in case of a fatal error while
interacting with Docker.

Cheers

-----

```
Calls `util.Cleanup`
- during fatal errors while interacting with docker
- after `rootCmd` successful execution
```