### PR TITLE
Use tar checksum instead of md5 of the files and fix memory bloat

### DIFF
--- a/filetree/data_test.go
+++ b/filetree/data_test.go
@@ -35,7 +35,7 @@ func BlankFileChangeInfo(path string) (f *FileInfo) {
 	result := FileInfo{
 		Path:     path,
 		TypeFlag: 1,
-		MD5sum:   [16]byte{1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+		Checksum:   [16]byte{1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0},
 	}
 	return &result
 }

--- a/filetree/data_test.go
+++ b/filetree/data_test.go
@@ -35,7 +35,7 @@ func BlankFileChangeInfo(path string) (f *FileInfo) {
 	result := FileInfo{
 		Path:     path,
 		TypeFlag: 1,
-		Checksum:   [16]byte{1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+		Checksum:   [8]byte{1, 1, 1, 0, 1, 0, 0, 0},
 	}
 	return &result
 }

--- a/filetree/efficiency_test.go
+++ b/filetree/efficiency_test.go
@@ -1,7 +1,7 @@
 package filetree
 
 import (
-	"archive/tar"
+	"github.com/chriscinelli/rawtar"
 	"testing"
 )
 
@@ -11,11 +11,11 @@ func TestEfficencyMap(t *testing.T) {
 		trees[idx] = NewFileTree()
 	}
 
-	trees[0].AddPath("/etc/nginx/nginx.conf", FileInfo{TarHeader: tar.Header{Size: 2000}})
-	trees[0].AddPath("/etc/nginx/public", FileInfo{TarHeader: tar.Header{Size: 3000}})
+	trees[0].AddPath("/etc/nginx/nginx.conf", FileInfo{TarHeader: rawtar.Header{Size: 2000}})
+	trees[0].AddPath("/etc/nginx/public", FileInfo{TarHeader: rawtar.Header{Size: 3000}})
 
-	trees[1].AddPath("/etc/nginx/nginx.conf", FileInfo{TarHeader: tar.Header{Size: 5000}})
-	trees[1].AddPath("/etc/athing", FileInfo{TarHeader: tar.Header{Size: 10000}})
+	trees[1].AddPath("/etc/nginx/nginx.conf", FileInfo{TarHeader: rawtar.Header{Size: 5000}})
+	trees[1].AddPath("/etc/athing", FileInfo{TarHeader: rawtar.Header{Size: 10000}})
 
 	trees[2].AddPath("/etc/.wh.nginx", *BlankFileChangeInfo("/etc/.wh.nginx"))
 

--- a/filetree/node.go
+++ b/filetree/node.go
@@ -1,7 +1,7 @@
 package filetree
 
 import (
-	"archive/tar"
+	"github.com/chriscinelli/rawtar"
 	"fmt"
 	"sort"
 	"strings"
@@ -124,7 +124,7 @@ func (node *FileNode) String() string {
 	}
 
 	display = node.Name
-	if node.Data.FileInfo.TarHeader.Typeflag == tar.TypeSymlink || node.Data.FileInfo.TarHeader.Typeflag == tar.TypeLink {
+	if node.Data.FileInfo.TarHeader.Typeflag == rawtar.TypeSymlink || node.Data.FileInfo.TarHeader.Typeflag == rawtar.TypeLink {
 		display += " → " + node.Data.FileInfo.TarHeader.Linkname
 	}
 	return diffTypeColor[node.Data.DiffType].Sprint(display)

--- a/filetree/node_test.go
+++ b/filetree/node_test.go
@@ -1,7 +1,7 @@
 package filetree
 
 import (
-	"archive/tar"
+	"github.com/chriscinelli/rawtar"
 	"testing"
 )
 
@@ -152,9 +152,9 @@ func TestDiffTypeFromRemovedChildren(t *testing.T) {
 
 func TestDirSize(t *testing.T) {
 	tree1 := NewFileTree()
-	tree1.AddPath("/etc/nginx/public1", FileInfo{TarHeader: tar.Header{Size: 100}})
-	tree1.AddPath("/etc/nginx/thing1", FileInfo{TarHeader: tar.Header{Size: 200}})
-	tree1.AddPath("/etc/nginx/public3/thing2", FileInfo{TarHeader: tar.Header{Size: 300}})
+	tree1.AddPath("/etc/nginx/public1", FileInfo{TarHeader: rawtar.Header{Size: 100}})
+	tree1.AddPath("/etc/nginx/thing1", FileInfo{TarHeader: rawtar.Header{Size: 200}})
+	tree1.AddPath("/etc/nginx/public3/thing2", FileInfo{TarHeader: rawtar.Header{Size: 300}})
 
 	node, _ := tree1.GetNode("/etc/nginx")
 	expected, actual := "----------        0:0      600 B ", node.MetadataString()

--- a/filetree/tree_test.go
+++ b/filetree/tree_test.go
@@ -263,7 +263,7 @@ func TestCompareWithNoChanges(t *testing.T) {
 		fakeData := FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			MD5sum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		}
 		lowerTree.AddPath(value, fakeData)
 		upperTree.AddPath(value, fakeData)
@@ -294,7 +294,7 @@ func TestCompareWithAdds(t *testing.T) {
 		lowerTree.AddPath(value, FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			MD5sum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		})
 	}
 
@@ -302,7 +302,7 @@ func TestCompareWithAdds(t *testing.T) {
 		upperTree.AddPath(value, FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			MD5sum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		})
 	}
 
@@ -354,12 +354,12 @@ func TestCompareWithChanges(t *testing.T) {
 		lowerTree.AddPath(value, FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			MD5sum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		})
 		upperTree.AddPath(value, FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			MD5sum:   [16]byte{1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [16]byte{1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0},
 		})
 	}
 
@@ -404,7 +404,7 @@ func TestCompareWithRemoves(t *testing.T) {
 		fakeData := FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			MD5sum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		}
 		lowerTree.AddPath(value, fakeData)
 	}
@@ -413,7 +413,7 @@ func TestCompareWithRemoves(t *testing.T) {
 		fakeData := FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			MD5sum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		}
 		upperTree.AddPath(value, fakeData)
 	}
@@ -474,7 +474,7 @@ func TestStackRange(t *testing.T) {
 		fakeData := FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			MD5sum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		}
 		lowerTree.AddPath(value, fakeData)
 	}
@@ -483,7 +483,7 @@ func TestStackRange(t *testing.T) {
 		fakeData := FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			MD5sum:   [16]byte{1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [16]byte{1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0},
 		}
 		upperTree.AddPath(value, fakeData)
 	}
@@ -500,7 +500,7 @@ func TestRemoveOnIterate(t *testing.T) {
 		fakeData := FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			MD5sum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		}
 		node, err := tree.AddPath(value, fakeData)
 		if err == nil && stringInSlice(node.Path(), []string{"/etc"}) {

--- a/filetree/tree_test.go
+++ b/filetree/tree_test.go
@@ -263,7 +263,7 @@ func TestCompareWithNoChanges(t *testing.T) {
 		fakeData := FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [8]byte{0, 0, 0, 0, 0, 0, 0, 0},
 		}
 		lowerTree.AddPath(value, fakeData)
 		upperTree.AddPath(value, fakeData)
@@ -294,7 +294,7 @@ func TestCompareWithAdds(t *testing.T) {
 		lowerTree.AddPath(value, FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [8]byte{0, 0, 0, 0, 0, 0, 0, 0},
 		})
 	}
 
@@ -302,7 +302,7 @@ func TestCompareWithAdds(t *testing.T) {
 		upperTree.AddPath(value, FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [8]byte{0, 0, 0, 0, 0, 0, 0, 0},
 		})
 	}
 
@@ -354,12 +354,12 @@ func TestCompareWithChanges(t *testing.T) {
 		lowerTree.AddPath(value, FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [8]byte{0, 0, 0, 0, 0, 0, 0, 0},
 		})
 		upperTree.AddPath(value, FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			Checksum:   [16]byte{1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [8]byte{1, 0, 0, 0, 0, 0, 0, 0},
 		})
 	}
 
@@ -404,7 +404,7 @@ func TestCompareWithRemoves(t *testing.T) {
 		fakeData := FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [8]byte{0, 0, 0, 0, 0, 0, 0, 0},
 		}
 		lowerTree.AddPath(value, fakeData)
 	}
@@ -413,7 +413,7 @@ func TestCompareWithRemoves(t *testing.T) {
 		fakeData := FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [8]byte{0, 0, 0, 0, 0, 0, 0, 0},
 		}
 		upperTree.AddPath(value, fakeData)
 	}
@@ -474,7 +474,7 @@ func TestStackRange(t *testing.T) {
 		fakeData := FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [8]byte{0, 0, 0, 0, 0, 0, 0, 0},
 		}
 		lowerTree.AddPath(value, fakeData)
 	}
@@ -483,7 +483,7 @@ func TestStackRange(t *testing.T) {
 		fakeData := FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			Checksum:   [16]byte{1, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [8]byte{0, 0, 0, 0, 0, 0, 0, 0},
 		}
 		upperTree.AddPath(value, fakeData)
 	}
@@ -500,7 +500,7 @@ func TestRemoveOnIterate(t *testing.T) {
 		fakeData := FileInfo{
 			Path:     value,
 			TypeFlag: 1,
-			Checksum:   [16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			Checksum:   [8]byte{0, 0, 0, 0, 0, 0, 0, 0},
 		}
 		node, err := tree.AddPath(value, fakeData)
 		if err == nil && stringInSlice(node.Path(), []string{"/etc"}) {


### PR DESCRIPTION
Fixes #27 and point 1 in #90 