### PR TITLE
Make changes to mode or owner show in UI

### DIFF
--- a/.data/Dockerfile
+++ b/.data/Dockerfile
@@ -11,3 +11,4 @@ RUN rm -rf /root/example/
 ADD .data/ /root/.data/
 RUN cp /root/saved.txt /tmp/saved.again1.txt
 RUN cp /root/saved.txt /root/.data/saved.again2.txt
+RUN chmod +x /root/saved.txt

--- a/filetree/data.go
+++ b/filetree/data.go
@@ -122,7 +122,10 @@ func (data *FileInfo) Copy() *FileInfo {
 // Compare determines the DiffType between two FileInfos based on the type and contents of each given FileInfo
 func (data *FileInfo) Compare(other FileInfo) DiffType {
 	if data.TypeFlag == other.TypeFlag {
-		if data.hash == other.hash {
+		if data.hash == other.hash &&
+			data.Mode == other.Mode &&
+			data.Uid == other.Uid &&
+			data.Gid == other.Gid {
 			return Unchanged
 		}
 	}


### PR DESCRIPTION
Previously, changes that did not affect the data in a file, such as a chmod or chown,
would incorrectly show up as unmodified in the UI. This change makes it so that changes
to the mode or owner (Mode, Gid, or Uid) of a file cause the file to appear modified
in the UI.

Should fix https://github.com/wagoodman/dive/issues/140 and https://github.com/wagoodman/dive/issues/124