### PR TITLE
Add homepage and description to Homebrew repo

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -43,3 +43,5 @@ brew:
   github:
     owner: wagoodman
     name: homebrew-dive
+  homepage: "https://github.com/wagoodman/dive/"
+  description: "A tool for exploring each layer in a docker image"


### PR DESCRIPTION
Per wagoodman/homebrew-dive#1, I have added a homepage and description tags so that GoReleaser should :crossed_fingers: add them on the next release.