### PR TITLE
Implementation of xdg spec about config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,20 +161,20 @@ You can override the CI config path with the `--ci-config` option.
 
 ## KeyBindings
 
-| Key Binding                               | Description                                    |
-| ----------------------------------------- | ---------------------------------------------- |
-| <kbd>Ctrl + C</kbd>                       | Exit                                           |
-| <kbd>Tab</kbd> or <kbd>Ctrl + Space</kbd> | Switch between the layer and filetree views    |
-| <kbd>Ctrl + F</kbd>                       | Filter files                                   |
-| <kbd>Ctrl + A</kbd>                       | Layer view: see aggregated image modifications |
-| <kbd>Ctrl + L</kbd>                       | Layer view: see current layer modifications    |
-| <kbd>Space</kbd>                          | Filetree view: collapse/uncollapse a directory |
-| <kbd>Ctrl + A</kbd>                       | Filetree view: show/hide added files           |
-| <kbd>Ctrl + R</kbd>                       | Filetree view: show/hide removed files         |
-| <kbd>Ctrl + M</kbd>                       | Filetree view: show/hide modified files        |
-| <kbd>Ctrl + U</kbd>                       | Filetree view: show/hide unmodified files      |
-| <kbd>PageUp</kbd>                         | Filetree view: scroll up a page                |
-| <kbd>PageDown</kbd>                       | Filetree view: scroll down a page              |
+Key Binding                                | Description
+-------------------------------------------|---------------------------------------------------------
+<kbd>Ctrl + C</kbd>                        | Exit
+<kbd>Tab</kbd> or <kbd>Ctrl + Space</kbd>  | Switch between the layer and filetree views
+<kbd>Ctrl + F</kbd>                        | Filter files
+<kbd>Ctrl + A</kbd>                        | Layer view: see aggregated image modifications
+<kbd>Ctrl + L</kbd>                        | Layer view: see current layer modifications
+<kbd>Space</kbd>                           | Filetree view: collapse/uncollapse a directory
+<kbd>Ctrl + A</kbd>                        | Filetree view: show/hide added files
+<kbd>Ctrl + R</kbd>                        | Filetree view: show/hide removed files
+<kbd>Ctrl + M</kbd>                        | Filetree view: show/hide modified files
+<kbd>Ctrl + U</kbd>                        | Filetree view: show/hide unmodified files
+<kbd>PageUp</kbd>                          | Filetree view: scroll up a page
+<kbd>PageDown</kbd>                        | Filetree view: scroll down a page
 
 ## UI Configuration
 

--- a/README.md
+++ b/README.md
@@ -161,20 +161,20 @@ You can override the CI config path with the `--ci-config` option.
 
 ## KeyBindings
 
-Key Binding                                | Description
--------------------------------------------|---------------------------------------------------------
-<kbd>Ctrl + C</kbd>                        | Exit
-<kbd>Tab</kbd> or <kbd>Ctrl + Space</kbd>  | Switch between the layer and filetree views
-<kbd>Ctrl + F</kbd>                        | Filter files
-<kbd>Ctrl + A</kbd>                        | Layer view: see aggregated image modifications
-<kbd>Ctrl + L</kbd>                        | Layer view: see current layer modifications
-<kbd>Space</kbd>                           | Filetree view: collapse/uncollapse a directory
-<kbd>Ctrl + A</kbd>                        | Filetree view: show/hide added files
-<kbd>Ctrl + R</kbd>                        | Filetree view: show/hide removed files
-<kbd>Ctrl + M</kbd>                        | Filetree view: show/hide modified files
-<kbd>Ctrl + U</kbd>                        | Filetree view: show/hide unmodified files
-<kbd>PageUp</kbd>                          | Filetree view: scroll up a page
-<kbd>PageDown</kbd>                        | Filetree view: scroll down a page
+| Key Binding                               | Description                                    |
+| ----------------------------------------- | ---------------------------------------------- |
+| <kbd>Ctrl + C</kbd>                       | Exit                                           |
+| <kbd>Tab</kbd> or <kbd>Ctrl + Space</kbd> | Switch between the layer and filetree views    |
+| <kbd>Ctrl + F</kbd>                       | Filter files                                   |
+| <kbd>Ctrl + A</kbd>                       | Layer view: see aggregated image modifications |
+| <kbd>Ctrl + L</kbd>                       | Layer view: see current layer modifications    |
+| <kbd>Space</kbd>                          | Filetree view: collapse/uncollapse a directory |
+| <kbd>Ctrl + A</kbd>                       | Filetree view: show/hide added files           |
+| <kbd>Ctrl + R</kbd>                       | Filetree view: show/hide removed files         |
+| <kbd>Ctrl + M</kbd>                       | Filetree view: show/hide modified files        |
+| <kbd>Ctrl + U</kbd>                       | Filetree view: show/hide unmodified files      |
+| <kbd>PageUp</kbd>                         | Filetree view: scroll up a page                |
+| <kbd>PageDown</kbd>                       | Filetree view: scroll down a page              |
 
 ## UI Configuration
 
@@ -228,6 +228,7 @@ layer:
 ```
 
 dive will search for configs in the following locations:
+- `$XDG_CONFIG_HOME/dive/*.yaml`
+- `$XDG_CONFIG_DIRS/dive/*.yaml`
+- `~/.config/dive/*.yaml`
 - `~/.dive.yaml`
-- `$XDG_CONFIG_HOME/dive.yaml`
-- `~/.config/dive.yaml`

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
+	"path"
 
 	"github.com/k0kubun/go-ansi"
 	"github.com/mitchellh/go-homedir"
@@ -13,6 +15,8 @@ import (
 	"github.com/wagoodman/dive/filetree"
 	"github.com/wagoodman/dive/utils"
 )
+
+const pathSep = string(os.PathSeparator)
 
 var cfgFile string
 var exportFile string
@@ -52,36 +56,8 @@ func init() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	if cfgFile != "" {
-		// Use config file from the flag.
-		viper.SetConfigFile(cfgFile)
-	} else {
-		// Find home directory.
-		home, err := homedir.Dir()
-		if err != nil {
-			fmt.Println(err)
-			utils.Exit(1)
-		}
-
-		// allow for:
-		//    ~/.dive.yaml
-		//    $XDG_CONFIG_HOME/dive.yaml
-		//    ~/.config/dive.yaml
-		hiddenHomeCfg := home + string(os.PathSeparator) + ".dive.yaml"
-		if _, err := os.Stat(hiddenHomeCfg); os.IsNotExist(err) {
-			viper.SetConfigName("dive")
-
-			xdgHome := os.Getenv("XDG_CONFIG_HOME")
-			if len(xdgHome) > 0 {
-				viper.AddConfigPath(xdgHome)
-			}
-
-			viper.AddConfigPath(home + string(os.PathSeparator) + ".config")
-
-		} else {
-			viper.SetConfigFile(hiddenHomeCfg)
-		}
-	}
+	filepathToCfg := getCfgFile(cfgFile)
+	viper.SetConfigFile(filepathToCfg)
 
 	viper.SetDefault("log.level", log.InfoLevel.String())
 	viper.SetDefault("log.path", "./dive.log")
@@ -147,4 +123,52 @@ func initLogging() {
 	log.SetLevel(level)
 	log.SetOutput(logFileObj)
 	log.Debug("Starting Dive...")
+}
+
+// getCfgFile checks for config file in paths from xdg specs
+// and in $HOME/.config/dive/ directory
+// defaults to $HOME/.dive.yaml
+func getCfgFile(fromFlag string) string {
+	if fromFlag != "" {
+		return fromFlag
+	}
+	
+	home, err := homedir.Dir()
+	if err != nil {
+		fmt.Println(err)
+		utils.Exit(0)
+	}
+
+	xdgHome := os.Getenv("XDG_CONFIG_HOME")
+	xdgDirs := os.Getenv("XDG_CONFIG_DIRS")
+	xdgPaths := append([]string{xdgHome}, strings.Split(xdgDirs, ":")...)
+	allDirs := append(xdgPaths, home + pathSep + ".config")
+
+	fmt.Println(allDirs)
+
+	for _, val := range allDirs {
+		file := findInPath(val)
+		if len(file) > 0 {
+			return file
+		}
+	}
+	return home + pathSep + "dive.yaml"
+}
+
+// findInPath returns first "*.yaml" file in path's subdirectory "dive"
+// if not found returns empty string
+func findInPath(pathTo string) string {
+	directory := pathTo + pathSep + "dive"
+	files, err := ioutil.ReadDir(directory)
+	if err != nil {
+		return ""
+	}
+
+	for _, file := range files {
+		filename := file.Name()
+		if path.Ext(filename) == ".yaml" {
+			return directory + pathSep + filename
+		}
+	}
+	return ""
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
 	"path"
+	"strings"
 
 	"github.com/k0kubun/go-ansi"
 	"github.com/mitchellh/go-homedir"
@@ -132,7 +132,7 @@ func getCfgFile(fromFlag string) string {
 	if fromFlag != "" {
 		return fromFlag
 	}
-	
+
 	home, err := homedir.Dir()
 	if err != nil {
 		fmt.Println(err)
@@ -142,9 +142,7 @@ func getCfgFile(fromFlag string) string {
 	xdgHome := os.Getenv("XDG_CONFIG_HOME")
 	xdgDirs := os.Getenv("XDG_CONFIG_DIRS")
 	xdgPaths := append([]string{xdgHome}, strings.Split(xdgDirs, ":")...)
-	allDirs := append(xdgPaths, home + pathSep + ".config")
-
-	fmt.Println(allDirs)
+	allDirs := append(xdgPaths, home+pathSep+".config")
 
 	for _, val := range allDirs {
 		file := findInPath(val)


### PR DESCRIPTION
Issue: #144

I have created function that looks for the config file with priority:
* `$XDG_CONFIG_HOME/dive/*.yaml`
* `$XDG_CONFIG_DIRS/dive/*.yaml` where env can hold multiple directiories separated with`:`, first has most priority and the last one lowest
* `$HOME/.config/dive/*.yaml`
* `$HOME/.dive.yaml` it's the default one for backward compatibility

If the directory has more than one file it takes first that has a `.yaml` extension.

I would like to ask about deeper look at the written functions names and variables names because I am not sure they should be named like this.