### PR TITLE
README: fix unknown toggle-unmodified-files config

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Key Binding                                | Description
 <kbd>Ctrl + A</kbd>                        | Filetree view: show/hide added files
 <kbd>Ctrl + R</kbd>                        | Filetree view: show/hide removed files
 <kbd>Ctrl + M</kbd>                        | Filetree view: show/hide modified files
-<kbd>Ctrl + U</kbd>                        | Filetree view: show/hide unmodified files
+<kbd>Ctrl + U</kbd>                        | Filetree view: show/hide unchanged files
 <kbd>PageUp</kbd>                          | Filetree view: scroll up a page
 <kbd>PageDown</kbd>                        | Filetree view: scroll down a page
 
@@ -214,7 +214,7 @@ keybinding:
   toggle-added-files: ctrl+a
   toggle-removed-files: ctrl+r
   toggle-modified-files: ctrl+m
-  toggle-unmodified-files: ctrl+u
+  toggle-unchanged-files: ctrl+u
   page-up: pgup
   page-down: pgdn
   


### PR DESCRIPTION
Fix unknown `toggle-unmodified-files` config.

The `keybinding.toggle-unmodified-files` is unknown config. actually `keybinding.toggle-unchanged-file`.

---

If `dive` continue to use `keybinding.toggle-unmodified-files` value, I'll change this pull request to following diff:

```diff
diff --git a/cmd/root.go b/cmd/root.go
index 01d0988..580484c 100644
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,7 +74,7 @@ func initConfig() {
 	viper.SetDefault("keybinding.toggle-added-files", "ctrl+a")
 	viper.SetDefault("keybinding.toggle-removed-files", "ctrl+r")
 	viper.SetDefault("keybinding.toggle-modified-files", "ctrl+m")
-	viper.SetDefault("keybinding.toggle-unchanged-files", "ctrl+u")
+	viper.SetDefault("keybinding.toggle-unmodified-files", "ctrl+u")
 	viper.SetDefault("keybinding.page-up", "pgup")
 	viper.SetDefault("keybinding.page-down", "pgdn")
 
diff --git a/ui/filetreeview.go b/ui/filetreeview.go
index 8f42cd4..9681c62 100644
--- a/ui/filetreeview.go
+++ b/ui/filetreeview.go
@@ -97,7 +97,7 @@ func NewFileTreeView(name string, gui *gocui.Gui, tree *filetree.FileTree, refTr
 		log.Panicln(err)
 	}
 
-	treeView.keybindingToggleUnchanged, err = keybinding.ParseAll(viper.GetString("keybinding.toggle-unchanged-files"))
+	treeView.keybindingToggleUnchanged, err = keybinding.ParseAll(viper.GetString("keybinding.toggle-unmodified-files"))
 	if err != nil {
 		log.Panicln(err)
 	}
```