### PR TITLE
use alpine:3.9 as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,3 @@
-FROM debian:stable-slim
+FROM alpine:3.9
 COPY dive /
 ENTRYPOINT ["/dive"]


### PR DESCRIPTION
Hello wagoodman 👋 

From what I gather, the docker image is built via placing the static go binary in the `debian:stable-slim` base image—I'm guessing this is either done via the CI or manually? Since I don't really see any code that builds the `dive` docker image in the repo 🤔

Anyway, compared to the `debian:stable-slim` image (22MBs compressed), `alpine:3.9` is 3MBs compressed, so using it as a base image will help with significantly decreasing the docker image size. This will be useful for CIs that will pull down the image to run against images (something we plan to do).

I compiled the `dive` binary and built the `Dockerfile` with the alpine base image and it worked fine analysing an image—unless I'm missing something that is needed from the debian base image? Happy to work through getting it work on `alpine` if there are any caveats.