### PR TITLE
fix tls config for docker

### DIFF
--- a/image/docker_image.go
+++ b/image/docker_image.go
@@ -85,6 +85,11 @@ func (image *dockerImageAnalyzer) Fetch() (io.ReadCloser, error) {
 		clientOpts = append(clientOpts, client.WithDialContext(helper.Dialer))
 
 	default:
+
+		if os.Getenv("DOCKER_TLS_VERIFY") != "" && os.Getenv("DOCKER_CERT_PATH") == "" {
+			os.Setenv("DOCKER_CERT_PATH", "~/.docker")
+		}
+
 		clientOpts = append(clientOpts, client.FromEnv)
 	}
 

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -12,6 +12,7 @@ func RunDockerCmd(cmdStr string, args ...string) error {
 	allArgs := cleanArgs(append([]string{cmdStr}, args...))
 
 	cmd := exec.Command("docker", allArgs...)
+	cmd.Env = os.Environ()
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
DOCKER_CERT_PATH is set which makes docker client use tls.
Also passing environment variables in docker command line exec call.

Fixes #209 