### PR TITLE
Update alpine based image

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,18 @@ builds:
 dockers:
   -
     binary: dive
+    dockerfile: Dockerfile.slim
+    image_templates:
+      - "wagoodman/dive:{{ .Tag }}-slim"
+      - "wagoodman/dive:v{{ .Major }}-slim"
+      - "wagoodman/dive:v{{ .Major }}.{{ .Minor }}-slim"
+      - "wagoodman/dive:slim"
+      - "quay.io/wagoodman/dive:{{ .Tag }}-slim"
+      - "quay.io/wagoodman/dive:v{{ .Major }}-slim"
+      - "quay.io/wagoodman/dive:v{{ .Major }}.{{ .Minor }}-slim"
+      - "quay.io/wagoodman/dive:slim"
+  -
+    binary: dive
     dockerfile: Dockerfile
     image_templates:
     - "wagoodman/dive:{{ .Tag }}"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -24,7 +24,18 @@ dockers:
     - "quay.io/wagoodman/dive:v{{ .Major }}"
     - "quay.io/wagoodman/dive:v{{ .Major }}.{{ .Minor }}"
     - "quay.io/wagoodman/dive:latest"
-
+  -
+    binary: dive
+    dockerfile: Dockerfile.full
+    image_templates:
+      - "wagoodman/dive:{{ .Tag }}-full"
+      - "wagoodman/dive:v{{ .Major }}-full"
+      - "wagoodman/dive:v{{ .Major }}.{{ .Minor }}-full"
+      - "wagoodman/dive:full"
+      - "quay.io/wagoodman/dive:{{ .Tag }}-full"
+      - "quay.io/wagoodman/dive:v{{ .Major }}-full"
+      - "quay.io/wagoodman/dive:v{{ .Major }}.{{ .Minor }}-full"
+      - "quay.io/wagoodman/dive:full"
 archive:
   format: tar.gz
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,6 +14,7 @@ builds:
 dockers:
   -
     binary: dive
+    dockerfile: Dockerfile
     image_templates:
     - "wagoodman/dive:{{ .Tag }}"
     - "wagoodman/dive:v{{ .Major }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,15 @@
-FROM debian:stable-slim
+FROM alpine:3.10
+
+ARG DOCKER_CLI_VERSION="19.03.1"
+ENV DOWNLOAD_URL="https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_CLI_VERSION.tgz"
+
+RUN apk --update add curl \
+    && mkdir -p /tmp/download \
+    && curl -L $DOWNLOAD_URL | tar -xz -C /tmp/download \
+    && mv /tmp/download/docker/docker /usr/local/bin/ \
+    && rm -rf /tmp/download \
+    && apk del curl \
+    && rm -rf /var/cache/apk/*
+
 COPY dive /
 ENTRYPOINT ["/dive"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,3 @@
 FROM alpine:3.10
-
-ARG DOCKER_CLI_VERSION="19.03.1"
-ENV DOWNLOAD_URL="https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_CLI_VERSION.tgz"
-
-RUN apk --update add curl \
-    && mkdir -p /tmp/download \
-    && curl -L $DOWNLOAD_URL | tar -xz -C /tmp/download \
-    && mv /tmp/download/docker/docker /usr/local/bin/ \
-    && rm -rf /tmp/download \
-    && apk del curl \
-    && rm -rf /var/cache/apk/*
-
 COPY dive /
 ENTRYPOINT ["/dive"]

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -1,0 +1,15 @@
+FROM alpine:3.10
+
+ARG DOCKER_CLI_VERSION="19.03.1"
+ENV DOWNLOAD_URL="https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_CLI_VERSION.tgz"
+
+RUN apk --update add curl \
+    && mkdir -p /tmp/download \
+    && curl -L $DOWNLOAD_URL | tar -xz -C /tmp/download \
+    && mv /tmp/download/docker/docker /usr/local/bin/ \
+    && rm -rf /tmp/download \
+    && apk del curl \
+    && rm -rf /var/cache/apk/*
+
+COPY dive /
+ENTRYPOINT ["/dive"]

--- a/Dockerfile.slim
+++ b/Dockerfile.slim
@@ -1,0 +1,3 @@
+FROM scratch
+COPY dive /
+ENTRYPOINT ["/dive"]

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ run-large: build
 	./build/$(BIN) amir20/clashleaders:latest
 
 build:
-	go build -o build/$(BIN)
+	CGO_ENABLED=0 go build -o build/$(BIN)
 
 release: test-coverage validate
 	./.scripts/tag.sh

--- a/image/docker_image.go
+++ b/image/docker_image.go
@@ -100,6 +100,11 @@ func (image *dockerImageAnalyzer) Fetch() (io.ReadCloser, error) {
 	}
 	_, _, err = image.client.ImageInspectWithRaw(ctx, image.id)
 	if err != nil {
+
+		if !utils.IsDockerClientAvailable() {
+			return nil, fmt.Errorf("cannot find docker client executable")
+		}
+
 		// don't use the API, the CLI has more informative output
 		fmt.Println("Image not available locally. Trying to pull '" + image.id + "'...")
 		err = utils.RunDockerCmd("pull", image.id)

--- a/utils/docker.go
+++ b/utils/docker.go
@@ -6,9 +6,13 @@ import (
 	"strings"
 )
 
+func IsDockerClientAvailable() bool {
+	_, err := exec.LookPath("docker")
+	return err == nil
+}
+
 // RunDockerCmd runs a given Docker command in the current tty
 func RunDockerCmd(cmdStr string, args ...string) error {
-
 	allArgs := cleanArgs(append([]string{cmdStr}, args...))
 
 	cmd := exec.Command("docker", allArgs...)


### PR DESCRIPTION
Addresses #211 by replacing the existing debian-slim image with an alpine image (reducing the file size from 65 MB to 21 MB. The original image did not include a docker client, which means that any docker pull operations could not be done by dive (though this can be done via the docker client lib, it does not provide as rich of output as the docker client executable). This has been addressed by also providing a alpine-based image with the docker client executable included.