### PR TITLE
rework Dockerfile.full: use two stages

### DIFF
--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -1,15 +1,9 @@
-FROM alpine:3.10
-
+FROM alpine:3.10 AS build
 ARG DOCKER_CLI_VERSION="19.03.1"
-ENV DOWNLOAD_URL="https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_CLI_VERSION.tgz"
-
 RUN apk --update add curl \
-    && mkdir -p /tmp/download \
-    && curl -L $DOWNLOAD_URL | tar -xz -C /tmp/download \
-    && mv /tmp/download/docker/docker /usr/local/bin/ \
-    && rm -rf /tmp/download \
-    && apk del curl \
-    && rm -rf /var/cache/apk/*
+ && curl -L https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_CLI_VERSION.tgz | tar -xzf - docker/docker --strip-component=1 -C /tmp
 
+FROM alpine:3.10
+COPY --from=build /tmp/docker /usr/local/bin
 COPY dive /
 ENTRYPOINT ["/dive"]


### PR DESCRIPTION
Instead of installing build dependencies and removing them from the final image, [multi-stage](https://docs.docker.com/develop/develop-images/multistage-build/) feature is used. In a first stage, `curl` is installed and `docker` CLI is downloaded. In the second stage, it is just copied.

Apart from that, `--strip-component` option of `tar` is used to extract the desired binary only.

---

Further thoughts:

- As commented in #214, the base of the second (and final) stage may be changed to `busybox` or `scratch`. Both `dive` and `docker` are statically compiled, so no other system resource should be required in the container.
- Instead of building `Dockerfile.full` as a completely different artifact from `Dockerfile`, I think it'd be desirable to make the relation between them explicit:

```dockerfile
FROM alpine:3.10 AS build
ARG DOCKER_CLI_VERSION="19.03.1"
RUN apk --update add curl \
 && curl -L https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_CLI_VERSION.tgz | tar -xzf - docker/docker --strip-component=1 -C /tmp

FROM wagoodman/dive
COPY --from=build /tmp/docker /usr/local/bin
```

Alternatively, both Dockerfiles can be merged:

```dockerfile
FROM alpine:3.10 AS default
COPY dive /
ENTRYPOINT ["/dive"]

FROM alpine:3.10 AS build
ARG DOCKER_CLI_VERSION="19.03.1"
RUN apk --update add curl \
 && curl -L https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_CLI_VERSION.tgz | tar -xzf - docker/docker --strip-component=1 -C /tmp

FROM default
COPY --from=build /tmp/docker /usr/local/bin
```

and build images as:

```
docker build -t wagoodman/dive --target=default .
docker build -t wagoodman/dive:full .
```

NOTE: this is supported by goreleaser through [`build_flag_templates`](https://goreleaser.com/customization/#Docker).