### PR TITLE
remove psuedo version from docker/distribution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/cespare/xxhash v1.1.0
 	github.com/docker/cli v0.0.0-20190303104010-8ddde26af67f
-	github.com/docker/distribution v0.0.0-20181126153310-93e082742a009850ac46962150b2f652a822c5ff // indirect
+	github.com/docker/distribution 93e082742a009850ac46962150b2f652a822c5ff // indirect
 	github.com/docker/docker v0.0.0-20181126153310-0b7cb16dde4a20d024c7be59801d63bcfd18611b
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.3.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/docker/cli v0.0.0-20190303104010-8ddde26af67f
 	github.com/docker/distribution 93e082742a009850ac46962150b2f652a822c5ff // indirect
-	github.com/docker/docker v0.0.0-20181126153310-0b7cb16dde4a20d024c7be59801d63bcfd18611b
+	github.com/docker/docker 0b7cb16dde4a20d024c7be59801d63bcfd18611b
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.3.3 // indirect
 	github.com/dustin/go-humanize v1.0.0


### PR DESCRIPTION
Hello,

I have go version go1.13 linux/amd64 on Arch Linux and whenever I try to `go get` dive, it fails to resolve `docker/distribution` dependency.

```go get -v github.com/docker/distribution@v0.0.0-20181126153310-93e082742a009850ac46962150b2f652a822c5ff
go: finding github.com v0.0.0-20181126153310-93e082742a009850ac46962150b2f652a822c5ff
go: finding github.com/docker/distribution v0.0.0-20181126153310-93e082742a009850ac46962150b2f652a822c5ff
go: finding github.com/docker v0.0.0-20181126153310-93e082742a009850ac46962150b2f652a822c5ff
go: finding github.com/docker/distribution v0.0.0-20181126153310-93e082742a009850ac46962150b2f652a822c5ff
go get github.com/docker/distribution@v0.0.0-20181126153310-93e082742a009850ac46962150b2f652a822c5ff: github.com/docker/distribution@v0.0.0-20181126153310-93e082742a009850ac46962150b2f652a822c5ff: invalid pseudo-version: revision is longer than canonical (93e082742a00)
```
Removing the psuedo-prefix `v0.0.0-20181126153310-` from module version and keeping only the commit revision hash `93e082742a009850ac46962150b2f652a822c5ff` makes it resolve the dependency and thus installation succeeds.