### PR TITLE
Add ability to specify source as a URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,11 @@ Analyze and image and get a pass/fail result based on the image efficiency and w
 **With Multiple Image Sources and Container Engines Supported**
 With the `--source` option, you can select where to fetch the container image from:
 ```bash
-dive <your-image-tag> --source podman
+dive <your-image> --source <source>
+```
+or
+```bash
+dive <source>://<your-image>
 ```
 
 With valid `source` options as such:

--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -39,16 +39,26 @@ func doAnalyzeCmd(cmd *cobra.Command, args []string) {
 		os.Exit(1)
 	}
 
-	engine, err := cmd.PersistentFlags().GetString("source")
-	if err != nil {
-		fmt.Printf("unable to determine engine: %v\n", err)
-		os.Exit(1)
+	var sourceType dive.ImageSource
+	var imageStr string
+
+	sourceType, imageStr = dive.DeriveImageSource(userImage)
+
+	if sourceType == dive.SourceUnknown {
+		sourceStr, err := cmd.PersistentFlags().GetString("source")
+		if err != nil {
+			fmt.Printf("unable to determine image source: %v\n", err)
+			os.Exit(1)
+		}
+
+		sourceType = dive.ParseImageSource(sourceStr)
+		imageStr = userImage
 	}
 
 	runtime.Run(runtime.Options{
 		Ci:         isCi,
-		Source:     dive.ParseImageSource(engine),
-		Image:      userImage,
+		Source:     sourceType,
+		Image:      imageStr,
 		ExportFile: exportFile,
 		CiConfig:   ciConfig,
 	})


### PR DESCRIPTION
This will allow the user to express the following command:
```
dive some-image:latest --source podman
```
as such:
```
dive podman://some-image:latest
```