### PR TITLE
Update deprecated goreleaser fields and add GHA workflow

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,24 @@
+name: 'snapshot'
+on: [push, pull_request]
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-go@v1
+      with:
+        go-version: '1.13.x'
+    - uses: actions/checkout@v1
+    - name: install deps
+      run: |
+        curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sudo sh -s -- -b /usr/local/bin/ latest
+        curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sudo sh -s -- -b /usr/local/bin/ latest
+        sudo apt-get update
+        sudo apt-get install -y libdevmapper-dev libgpgme11-dev
+    - run: go get ./...
+    - run: golangci-lint run -v
+    - run: goreleaser --snapshot --skip-publish --rm-dist
+    - run: docker images
+    - uses: actions/upload-artifact@master
+      with:
+        name: dist
+        path: dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,24 +25,24 @@ dockers:
     - "quay.io/wagoodman/dive:v{{ .Major }}"
     - "quay.io/wagoodman/dive:v{{ .Major }}.{{ .Minor }}"
     - "quay.io/wagoodman/dive:latest"
-archive:
-  format: tar.gz
 
-  format_overrides:
-    - goos: windows
-      format: zip
+archives:
+  - format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
 
-nfpm:
-  license: MIT
-  maintainer: Alex Goodman
-  homepage: https://github.com/wagoodman/dive/
-  formats:
-    - deb
-    - rpm
+nfpms:
+  - license: MIT
+    maintainer: Alex Goodman
+    homepage: https://github.com/wagoodman/dive/
+    formats:
+      - deb
+      - rpm
 
-brew:
-  github:
-    owner: wagoodman
-    name: homebrew-dive
-  homepage: "https://github.com/wagoodman/dive/"
-  description: "A tool for exploring each layer in a docker image"
+brews:
+  - github:
+      owner: wagoodman
+      name: homebrew-dive
+    homepage: "https://github.com/wagoodman/dive/"
+    description: "A tool for exploring each layer in a docker image"


### PR DESCRIPTION
On the one hand, fields `archive`, `nfpm` and `brew` are updated, in order to get rid of deprecation notices: https://goreleaser.com/deprecations/

On the other hand, a GitHub Actions workflow is added. golangci-lint and goreleaser (`--skip-publish`) are executed after each push or PR. The artifacts (dir `dist`) are available to download. See, for example: https://github.com/1138-4EB/dive/commit/0ffd1d0d7cde528c510527e1e6ea3ff624327f33/checks?check_suite_id=297503630. This does not replace the existing CircleCI workflow.