### PR TITLE
Add GHA workflow to build dev image weekly

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,32 @@
+name: 'dev'
+on:
+  push:
+    paths:
+      - '.github/workflows/dev.yml'
+  schedule:
+    - cron: '0 0 * * 5'
+env:
+  DOCKER_BUILDKIT: '1'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_REGISTRY: docker.pkg.github.com
+    steps:
+    - uses: actions/checkout@v1
+    - name: build image
+      run: |
+        docker build -t wagoodman/dive:dev - <<EOF
+        FROM golang:alpine AS build
+        RUN apk add -U --no-cache gpgme-dev gcc musl-dev btrfs-progs-dev lvm2-dev curl git \
+         && curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh \
+         && curl -L https://download.docker.com/linux/static/stable/x86_64/docker-19.03.1.tgz | tar -xzf - docker/docker --strip-component=1 -C /usr/local/bin
+        EOF
+    - name: docker push
+      if: github.repository == 'wagoodman/dive'
+      run: |
+        echo "$GITHUB_TOKEN" | docker login -u dive-gha --password-stdin "$DOCKER_REGISTRY"
+        docker push ${DOCKER_REGISTRY}/wagoodman/dive/dev:latest
+        docker logout "$DOCKER_REGISTRY"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,11 +25,20 @@ jobs:
   docker:
     needs: [ pkg ]
     runs-on: ubuntu-latest
+    env:
+      DOCKER_REGISTRY: docker.pkg.github.com
     steps:
     - uses: actions/setup-go@v1
       with:
         go-version: '1.13.x'
     - uses: actions/checkout@v1
+    - name: docker pull
+      run: |
+        echo "$GITHUB_TOKEN" | docker login -u dive-gha --password-stdin "$DOCKER_REGISTRY"
+        docker pull docker.pkg.github.com/wagoodman/dive/dev:latest
+        docker logout "$DOCKER_REGISTRY"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - run: ./docker.sh
     - run: docker images
     - uses: actions/upload-artifact@master

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,7 @@
 name: 'snapshot'
-on: [push, pull_request]
+on: [ push, pull_request ]
 jobs:
-  snapshot:
+  pkg:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/setup-go@v1
@@ -17,8 +17,22 @@ jobs:
     - run: go get ./...
     - run: golangci-lint run -v
     - run: goreleaser --snapshot --skip-publish --rm-dist
+    - uses: actions/upload-artifact@master
+      with:
+        name: ubuntu
+        path: dist
+
+  docker:
+    needs: [ pkg ]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-go@v1
+      with:
+        go-version: '1.13.x'
+    - uses: actions/checkout@v1
+    - run: ./docker.sh
     - run: docker images
     - uses: actions/upload-artifact@master
       with:
-        name: dist
+        name: alpine
         path: dist

--- a/.goreleaser.docker.yml
+++ b/.goreleaser.docker.yml
@@ -1,0 +1,25 @@
+release:
+  prerelease: true
+
+builds:
+  - binary: dive
+    goos:
+      - linux
+    goarch:
+      - amd64
+    ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.buildTime={{.Date}}`.
+
+dockers:
+  -
+    binaries:
+      - dive
+    dockerfile: Dockerfile
+    image_templates:
+      - "wagoodman/dive:{{ .Tag }}"
+      - "wagoodman/dive:v{{ .Major }}"
+      - "wagoodman/dive:v{{ .Major }}.{{ .Minor }}"
+      - "wagoodman/dive:latest"
+      - "quay.io/wagoodman/dive:{{ .Tag }}"
+      - "quay.io/wagoodman/dive:v{{ .Major }}"
+      - "quay.io/wagoodman/dive:v{{ .Major }}.{{ .Minor }}"
+      - "quay.io/wagoodman/dive:latest"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,21 +11,6 @@ builds:
       - amd64
     ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.buildTime={{.Date}}`.
 
-dockers:
-  -
-    binaries:
-      - dive
-    dockerfile: Dockerfile
-    image_templates:
-    - "wagoodman/dive:{{ .Tag }}"
-    - "wagoodman/dive:v{{ .Major }}"
-    - "wagoodman/dive:v{{ .Major }}.{{ .Minor }}"
-    - "wagoodman/dive:latest"
-    - "quay.io/wagoodman/dive:{{ .Tag }}"
-    - "quay.io/wagoodman/dive:v{{ .Major }}"
-    - "quay.io/wagoodman/dive:v{{ .Major }}.{{ .Minor }}"
-    - "quay.io/wagoodman/dive:latest"
-
 archives:
   - format: tar.gz
     format_overrides:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM alpine:3.10
-COPY --from=wagoodman/dive:dev /usr/local/bin/docker /usr/local/bin/
+COPY --from=docker.pkg.github.com/wagoodman/dive/dev:latest /usr/local/bin/docker /usr/local/bin/
 COPY dive /usr/local/bin/
 RUN apk add -U --no-cache gpgme device-mapper
 ENTRYPOINT ["/usr/local/bin/dive"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,5 @@
-FROM debian:sid-slim
-RUN apt-get update && apt-get install -y \
-        curl \
-        libdevmapper1.02.1 \
-        libgpgme11-dev \
-     && rm -rf /var/lib/apt/lists/* \
-     && ln -s /lib/x86_64-linux-gnu/libdevmapper.so.1.02.1 /usr/lib/libdevmapper.so.1.02
-ARG DOCKER_CLI_VERSION="19.03.1"
-RUN curl -L https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_CLI_VERSION.tgz | \
-    tar -xz  --strip-component=1 -C /usr/local/bin/ docker/docker
+FROM alpine:3.10
+COPY --from=wagoodman/dive:dev /usr/local/bin/docker /usr/local/bin/
 COPY dive /usr/local/bin/
+RUN apk add -U --no-cache gpgme device-mapper
 ENTRYPOINT ["/usr/local/bin/dive"]

--- a/docker.sh
+++ b/docker.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env sh
+
+set -e
+
+cd "$(dirname $0)"
+
+docker build -t wagoodman/dive:dev - <<EOF
+FROM golang:alpine AS build
+RUN apk add -U --no-cache gpgme-dev gcc musl-dev btrfs-progs-dev lvm2-dev curl git \
+ && curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh \
+ && curl -L https://download.docker.com/linux/static/stable/x86_64/docker-19.03.1.tgz | tar -xzf - docker/docker --strip-component=1 -C /usr/local/bin
+EOF
+
+docker run --rm \
+  -v //var/run/docker.sock://var/run/docker.sock \
+  -v /$(pwd)://src \
+  -w //src \
+  wagoodman/dive:dev \
+  goreleaser \
+    -f .goreleaser.docker.yml \
+    --snapshot \
+    --skip-publish \
+    --rm-dist
+
+sudo chown -R $USER:$USER dist

--- a/docker.sh
+++ b/docker.sh
@@ -4,13 +4,6 @@ set -e
 
 cd "$(dirname $0)"
 
-docker build -t wagoodman/dive:dev - <<EOF
-FROM golang:alpine AS build
-RUN apk add -U --no-cache gpgme-dev gcc musl-dev btrfs-progs-dev lvm2-dev curl git \
- && curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh \
- && curl -L https://download.docker.com/linux/static/stable/x86_64/docker-19.03.1.tgz | tar -xzf - docker/docker --strip-component=1 -C /usr/local/bin
-EOF
-
 docker run --rm \
   -v //var/run/docker.sock://var/run/docker.sock \
   -v /$(pwd)://src \


### PR DESCRIPTION
This PR is based on #245, and should be merged later. See https://github.com/1138-4EB/dive/compare/alpine...1138-4EB:dev-image

Instead of building image `wagoodman/dive:dev` each time, a GitHub Actions workflow is used to build and push the image to `docker.pkg.github.com/wagoodman/dive/dev:latest` weekly (or when the corresponding workflow file is modified).