### PR TITLE
Allow setting `source` in config file (fixes #267)

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/wagoodman/dive/runtime"
 )
 
@@ -45,13 +46,13 @@ func doAnalyzeCmd(cmd *cobra.Command, args []string) {
 	sourceType, imageStr = dive.DeriveImageSource(userImage)
 
 	if sourceType == dive.SourceUnknown {
-		sourceStr, err := cmd.PersistentFlags().GetString("source")
-		if err != nil {
-			fmt.Printf("unable to determine image source: %v\n", err)
+		sourceStr := viper.GetString("source")
+		sourceType = dive.ParseImageSource(sourceStr)
+		if sourceType == dive.SourceUnknown {
+			fmt.Printf("unable to determine image source: %v\n", sourceStr)
 			os.Exit(1)
 		}
 
-		sourceType = dive.ParseImageSource(sourceStr)
 		imageStr = userImage
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,6 +66,8 @@ func initCli() {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
+	var err error
+
 	viper.SetDefault("log.level", log.InfoLevel.String())
 	viper.SetDefault("log.path", "./dive.log")
 	viper.SetDefault("log.enabled", false)
@@ -97,7 +99,11 @@ func initConfig() {
 
 	viper.SetDefault("container-engine", "docker")
 
-	viper.BindPFlag("source", rootCmd.PersistentFlags().Lookup("source"))
+	err = viper.BindPFlag("source", rootCmd.PersistentFlags().Lookup("source"))
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 
 	viper.SetEnvPrefix("DIVE")
 	// replace all - with _ when looking for matching environment variables
@@ -112,7 +118,7 @@ func initConfig() {
 	} else {
 		viper.SetConfigFile(cfgFile)
 	}
-	err := viper.ReadInConfig()
+	err = viper.ReadInConfig()
 	if err == nil {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
 	} else if cfgFile != "" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -97,6 +97,8 @@ func initConfig() {
 
 	viper.SetDefault("container-engine", "docker")
 
+	viper.BindPFlag("source", rootCmd.PersistentFlags().Lookup("source"))
+
 	viper.SetEnvPrefix("DIVE")
 	// replace all - with _ when looking for matching environment variables
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))


### PR DESCRIPTION
```yaml
✗ cat dive.yaml 
source: podman
✗ dive --config dive.yaml 633
Using config file: dive.yaml
Image Source: podman://633
```