### PR TITLE
Require golang 1.10+ (closes #278)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ or download the latest Darwin build from the [releases page](https://github.com/
 Download the [latest release](https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_windows_amd64.zip).
 
 **Go tools**
-Requires Go version 1.9 or higher.
+Requires Go version 1.10 or higher.
 
 ```bash
 go get github.com/wagoodman/dive

--- a/runtime/ui/view/layer.go
+++ b/runtime/ui/view/layer.go
@@ -301,7 +301,7 @@ func (v *Layer) Render() error {
 		width, _ := g.Size()
 		if v.constrainedRealEstate {
 			headerStr := format.RenderNoHeader(width, isSelected)
-			headerStr += fmt.Sprintf("\nLayer")
+			headerStr += "\nLayer"
 			_, err := fmt.Fprintln(v.header, headerStr)
 			if err != nil {
 				return err


### PR DESCRIPTION
Because `strings.Builder` was added in 1.10 - https://www.calhoun.io/concatenating-and-building-strings-in-go/
```
✗ sudo snap refresh go --channel 1.9/stable --classic
go (1.9/stable) 1.9.7 from Michael Hudson-Doyle (mwhudson) refreshed
✗ go version
go version go1.9.7 linux/amd64
✗ GO111MODULE=auto go build
# github.com/wagoodman/dive/runtime/ci
runtime/ci/evaluator.go:137:9: undefined: strings.Builder
```