### PR TITLE
Remove unnecessary use of fmt.Sprintf

### DIFF
--- a/runtime/ui/view/layer.go
+++ b/runtime/ui/view/layer.go
@@ -301,7 +301,7 @@ func (v *Layer) Render() error {
 		width, _ := g.Size()
 		if v.constrainedRealEstate {
 			headerStr := format.RenderNoHeader(width, isSelected)
-			headerStr += fmt.Sprintf("\nLayer")
+			headerStr += "\nLayer"
 			_, err := fmt.Fprintln(v.header, headerStr)
 			if err != nil {
 				return err


### PR DESCRIPTION
Fixes the following staticcheck error:

```
 ##[error]runtime/ui/view/layer.go:304:17: S1039: unnecessary use of fmt.Sprintf (gosimple)
			headerStr += fmt.Sprintf("\nLayer")
			             ^
```