### PR TITLE
Add image name to details view

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,7 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golangci/golangci-lint v1.32.0 h1:3wL5pvhTpRvlvtosoZecS+hu40IAiJl1qlZQuXIFBAg=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0 h1:+dTQ8DZQJz0Mb/HjFlkptS1FeQ4cWSnN941F8aEG4SQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=

--- a/runtime/run.go
+++ b/runtime/run.go
@@ -107,7 +107,7 @@ func run(enableUi bool, options Options, imageResolver image.Resolver, events ev
 			// enough sleep will prevent this behavior (todo: remove this hack)
 			time.Sleep(100 * time.Millisecond)
 
-			err = ui.Run(analysis, treeStack)
+			err = ui.Run(options.Image, analysis, treeStack)
 			if err != nil {
 				events.exitWithError(err)
 				return

--- a/runtime/ui/app.go
+++ b/runtime/ui/app.go
@@ -26,13 +26,13 @@ var (
 	appSingleton *app
 )
 
-func newApp(gui *gocui.Gui, analysis *image.AnalysisResult, cache filetree.Comparer) (*app, error) {
+func newApp(gui *gocui.Gui, imageName string, analysis *image.AnalysisResult, cache filetree.Comparer) (*app, error) {
 	var err error
 	once.Do(func() {
 		var controller *Controller
 		var globalHelpKeys []*key.Binding
 
-		controller, err = NewCollection(gui, analysis, cache)
+		controller, err = NewCollection(gui, imageName, analysis, cache)
 		if err != nil {
 			return
 		}
@@ -127,7 +127,7 @@ func (a *app) quit() error {
 }
 
 // Run is the UI entrypoint.
-func Run(analysis *image.AnalysisResult, treeStack filetree.Comparer) error {
+func Run(imageName string, analysis *image.AnalysisResult, treeStack filetree.Comparer) error {
 	var err error
 
 	g, err := gocui.NewGui(gocui.OutputNormal)
@@ -136,7 +136,7 @@ func Run(analysis *image.AnalysisResult, treeStack filetree.Comparer) error {
 	}
 	defer g.Close()
 
-	_, err = newApp(g, analysis, treeStack)
+	_, err = newApp(g, imageName, analysis, treeStack)
 	if err != nil {
 		return err
 	}

--- a/runtime/ui/controller.go
+++ b/runtime/ui/controller.go
@@ -15,8 +15,8 @@ type Controller struct {
 	views *view.Views
 }
 
-func NewCollection(g *gocui.Gui, analysis *image.AnalysisResult, cache filetree.Comparer) (*Controller, error) {
-	views, err := view.NewViews(g, analysis, cache)
+func NewCollection(g *gocui.Gui, imageName string, analysis *image.AnalysisResult, cache filetree.Comparer) (*Controller, error) {
+	views, err := view.NewViews(g, imageName, analysis, cache)
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/ui/view/details.go
+++ b/runtime/ui/view/details.go
@@ -21,6 +21,7 @@ type Details struct {
 	gui            *gocui.Gui
 	view           *gocui.View
 	header         *gocui.View
+	imageName	   string
 	efficiency     float64
 	inefficiencies filetree.EfficiencySlice
 	imageSize      uint64
@@ -29,12 +30,13 @@ type Details struct {
 }
 
 // newDetailsView creates a new view object attached the the global [gocui] screen object.
-func newDetailsView(gui *gocui.Gui, efficiency float64, inefficiencies filetree.EfficiencySlice, imageSize uint64) (controller *Details) {
+func newDetailsView(gui *gocui.Gui, imageName string, efficiency float64, inefficiencies filetree.EfficiencySlice, imageSize uint64) (controller *Details) {
 	controller = new(Details)
 
 	// populate main fields
 	controller.name = "details"
 	controller.gui = gui
+	controller.imageName = imageName
 	controller.efficiency = efficiency
 	controller.inefficiencies = inefficiencies
 	controller.imageSize = imageSize
@@ -148,6 +150,7 @@ func (v *Details) Render() error {
 		}
 	}
 
+	imageNameStr := fmt.Sprintf("%s %s", format.Header("Image name:"), v.imageName)
 	imageSizeStr := fmt.Sprintf("%s %s", format.Header("Total Image size:"), humanize.Bytes(v.imageSize))
 	effStr := fmt.Sprintf("%s %d %%", format.Header("Image efficiency score:"), int(100.0*v.efficiency))
 	wastedSpaceStr := fmt.Sprintf("%s %s", format.Header("Potential wasted space:"), humanize.Bytes(uint64(wastedSpace)))
@@ -179,6 +182,7 @@ func (v *Details) Render() error {
 		lines = append(lines, format.Header("Command:"))
 		lines = append(lines, v.currentLayer.Command)
 		lines = append(lines, "\n"+imageHeaderStr)
+		lines = append(lines, imageNameStr)
 		lines = append(lines, imageSizeStr)
 		lines = append(lines, wastedSpaceStr)
 		lines = append(lines, effStr+"\n")

--- a/runtime/ui/view/details.go
+++ b/runtime/ui/view/details.go
@@ -21,7 +21,7 @@ type Details struct {
 	gui            *gocui.Gui
 	view           *gocui.View
 	header         *gocui.View
-	imageName	   string
+	imageName      string
 	efficiency     float64
 	inefficiencies filetree.EfficiencySlice
 	imageSize      uint64

--- a/runtime/ui/view/views.go
+++ b/runtime/ui/view/views.go
@@ -15,7 +15,7 @@ type Views struct {
 	Debug   *Debug
 }
 
-func NewViews(g *gocui.Gui, analysis *image.AnalysisResult, cache filetree.Comparer) (*Views, error) {
+func NewViews(g *gocui.Gui, imageName string, analysis *image.AnalysisResult, cache filetree.Comparer) (*Views, error) {
 	Layer, err := newLayerView(g, analysis.Layers)
 	if err != nil {
 		return nil, err
@@ -34,7 +34,7 @@ func NewViews(g *gocui.Gui, analysis *image.AnalysisResult, cache filetree.Compa
 
 	Filter := newFilterView(g)
 
-	Details := newDetailsView(g, analysis.Efficiency, analysis.Inefficiencies, analysis.SizeBytes)
+	Details := newDetailsView(g, imageName, analysis.Efficiency, analysis.Inefficiencies, analysis.SizeBytes)
 
 	Debug := newDebugView(g)
 


### PR DESCRIPTION
When frequently opening multiple images perhaps concurrently on multiple
terminals, it would be convenient to have the image name displayed.

This commit adds the image name to the Image Details view.
Image name is trickled down as an additional string argument

design alternatives discarded:
pass in analysis struct - is not related to analysis
pass new struct with image attributes - premature abstraction