### PR TITLE
WIP: Add Skopeo source

### DIFF
--- a/dive/get_image_resolver.go
+++ b/dive/get_image_resolver.go
@@ -5,6 +5,7 @@ import (
 	"github.com/wagoodman/dive/dive/image"
 	"github.com/wagoodman/dive/dive/image/docker"
 	"github.com/wagoodman/dive/dive/image/podman"
+	"github.com/wagoodman/dive/dive/image/skopeo"
 	"net/url"
 	"strings"
 )
@@ -14,14 +15,15 @@ const (
 	SourceDockerEngine
 	SourcePodmanEngine
 	SourceDockerArchive
+	SourceSkopeo
 )
 
 type ImageSource int
 
-var ImageSources = []string{SourceDockerEngine.String(), SourcePodmanEngine.String(), SourceDockerArchive.String()}
+var ImageSources = []string{SourceDockerEngine.String(), SourcePodmanEngine.String(), SourceDockerArchive.String(), SourceSkopeo.String()}
 
 func (r ImageSource) String() string {
-	return [...]string{"unknown", "docker", "podman", "docker-archive"}[r]
+	return [...]string{"unknown", "docker", "podman", "docker-archive", "skopeo"}[r]
 }
 
 func ParseImageSource(r string) ImageSource {
@@ -33,6 +35,8 @@ func ParseImageSource(r string) ImageSource {
 	case SourceDockerArchive.String():
 		return SourceDockerArchive
 	case "docker-tar":
+		return SourceDockerArchive
+	case SourceSkopeo.String():
 		return SourceDockerArchive
 	default:
 		return SourceUnknown
@@ -56,7 +60,8 @@ func DeriveImageSource(image string) (ImageSource, string) {
 		return SourceDockerArchive, imageSource
 	case "docker-tar":
 		return SourceDockerArchive, imageSource
-
+	case SourceSkopeo.String():
+		return SourceSkopeo, imageSource
 	}
 	return SourceUnknown, ""
 }
@@ -69,6 +74,8 @@ func GetImageResolver(r ImageSource) (image.Resolver, error) {
 		return podman.NewResolverFromEngine(), nil
 	case SourceDockerArchive:
 		return docker.NewResolverFromArchive(), nil
+	case SourceSkopeo:
+		return skopeo.NewResolverFromEngine(), nil
 	}
 
 	return nil, fmt.Errorf("unable to determine image resolver")

--- a/dive/image/docker/config.go
+++ b/dive/image/docker/config.go
@@ -5,7 +5,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type config struct {
+type Config struct {
 	History []historyEntry `json:"history"`
 	RootFs  rootFs         `json:"rootfs"`
 }
@@ -24,8 +24,8 @@ type historyEntry struct {
 	EmptyLayer bool   `json:"empty_layer"`
 }
 
-func newConfig(configBytes []byte) config {
-	var imageConfig config
+func NewConfig(configBytes []byte) Config {
+	var imageConfig Config
 	err := json.Unmarshal(configBytes, &imageConfig)
 	if err != nil {
 		logrus.Panic(err)

--- a/dive/image/docker/manifest.go
+++ b/dive/image/docker/manifest.go
@@ -5,14 +5,14 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type manifest struct {
+type Manifest struct {
 	ConfigPath    string   `json:"Config"`
 	RepoTags      []string `json:"RepoTags"`
 	LayerTarPaths []string `json:"Layers"`
 }
 
-func newManifest(manifestBytes []byte) manifest {
-	var manifest []manifest
+func newManifest(manifestBytes []byte) Manifest {
+	var manifest []Manifest
 	err := json.Unmarshal(manifestBytes, &manifest)
 	if err != nil {
 		logrus.Panic(err)

--- a/dive/image/skopeo/image_archive.go
+++ b/dive/image/skopeo/image_archive.go
@@ -1,0 +1,49 @@
+package skopeo
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"github.com/wagoodman/dive/dive/filetree"
+	"github.com/wagoodman/dive/dive/image/docker"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+)
+
+func directoryToImageArchive(dir string) (*docker.ImageArchive, error) {
+	img := &docker.ImageArchive{
+		LayerMap: make(map[string]*filetree.FileTree),
+	}
+
+	bin, err := ioutil.ReadFile(filepath.Join(dir, "manifest.json"))
+	if err != nil {
+		return nil, err
+	}
+	img.Manifest = newManifest(bin)
+
+	bin, err = ioutil.ReadFile(filepath.Join(dir, img.Manifest.ConfigPath))
+	if err != nil {
+		return nil, err
+	}
+	img.Config = docker.NewConfig(bin)
+
+	for _, layer := range img.Manifest.LayerTarPaths {
+		fd, err := os.Open(filepath.Join(dir, layer))
+		if err != nil {
+			return nil, err
+		}
+		defer fd.Close()
+
+		gzipReader, err := gzip.NewReader(fd)
+		if err != nil {
+			return nil, err
+		}
+		tree, err := docker.ProcessLayerTar(layer, tar.NewReader(gzipReader))
+		if err != nil {
+			return nil, err
+		}
+		img.LayerMap[tree.Name] = tree
+	}
+
+	return img, nil
+}

--- a/dive/image/skopeo/manifest.go
+++ b/dive/image/skopeo/manifest.go
@@ -1,0 +1,42 @@
+package skopeo
+
+import (
+	"encoding/json"
+	"github.com/sirupsen/logrus"
+	"github.com/wagoodman/dive/dive/image/docker"
+	"strings"
+)
+
+type manifestV2 struct {
+	SchemaVersion int     `json:"schemaVersion"`
+	MediaType     string  `json:"mediaType"`
+	Config        config  `json:"config"`
+	Layers        []layer `json:"layers"`
+}
+
+type config struct {
+	MediaType string `json:"mediaType"`
+	Size      int    `json:"size"`
+	Digest    string `json:"digest"`
+}
+
+type layer struct {
+	MediaType string `json:"mediaType"`
+	Size      int    `json:"size"`
+	Digest    string `json:"digest"`
+}
+
+func newManifest(manifestBytes []byte) docker.Manifest {
+	var manifest manifestV2
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		logrus.Panic(err)
+	}
+	var layers []string
+	for _, l := range manifest.Layers {
+		layers = append(layers, strings.TrimPrefix(l.Digest, "sha256:"))
+	}
+	return docker.Manifest{
+		ConfigPath:    strings.TrimPrefix(manifest.Config.Digest, "sha256:"),
+		LayerTarPaths: layers,
+	}
+}

--- a/dive/image/skopeo/resolver.go
+++ b/dive/image/skopeo/resolver.go
@@ -1,0 +1,40 @@
+package skopeo
+
+import (
+	"fmt"
+	"github.com/wagoodman/dive/dive/image"
+	"io/ioutil"
+	"os"
+	"os/exec"
+)
+
+type resolver struct{}
+
+func NewResolverFromEngine() *resolver {
+	return &resolver{}
+}
+
+func (r *resolver) Build(args []string) (*image.Image, error) {
+	return nil, fmt.Errorf("unsupported platform")
+}
+
+func (r *resolver) Fetch(path string) (*image.Image, error) {
+	dir, err := ioutil.TempDir("", "skopeo")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(dir)
+	cmd := exec.Command("skopeo", "copy", "--override-os=linux", "docker://"+path, "dir:"+dir)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = os.Environ()
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+
+	img, err := directoryToImageArchive(dir)
+	if err != nil {
+		return nil, err
+	}
+	return img.ToImage()
+}


### PR DESCRIPTION
Fixes #130

The main benefit of this source is that it doesn't need a daemon. 

For instance, on macOS, just run:
```
$ brew install skopeo
$ dive skopeo://redis 
Image Source: skopeo://redis
Fetching image... (this can take a while for large images)
Getting image source signatures
Copying blob 852e50cd189d done  
Copying blob 76190fa64fb8 done  
Copying blob 9cbb1b61e01b done  
Copying blob d048021f2aae done  
Copying blob 6f4b2af24926 done  
Copying blob 1cf1d6922fba done  
Copying config 74d1072210 done  
Writing manifest to image destination
Storing signatures
Analyzing image...
Building cache...
```

I wanted to browse an image on my Mac. This was the easiest solution to do it without having a daemon running :)

TODO:
* decide wether code reading the tar layer should be extracted to a new package shared by Docker and Skopeo.
* handle extra flags for Skopeo (`--override-os=linux` is most of the time mandatory)
* add .exe extension for Windows and check if it works.

Let me know what you think about this!