### PR TITLE
Fix stream podman command hanging

### DIFF
--- a/dive/image/podman/cli.go
+++ b/dive/image/podman/cli.go
@@ -40,6 +40,7 @@ func streamPodmanCmd(args ...string) (error, io.Reader) {
 	if err != nil {
 		return err, nil
 	}
+	defer writer.Close()
 
 	cmd.Stdout = writer
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
I found that using an image that is not in podman locally would hang dive. It seems like this writer not being closed on the streamPodmanCmd function was the culprit.
To test this issue, fist make sure ubuntu is not in podman and then the outputs should be:

Before:
```
$ dive podman://docker.io/library/ubuntu
Image Source: podman://docker.io/library/ubuntu
Fetching image... (this can take a while for large images)
Error: unable to find 'docker.io/library/ubuntu' in local storage: no such image
(here it will hang)
```
After:
```
$ dive podman://docker.io/library/ubuntu
Image Source: podman://docker.io/library/ubuntu
Fetching image... (this can take a while for large images)
Error: unable to find 'docker.io/library/ubuntu' in local storage: no such image
cannot fetch image
unable to resolve image 'docker.io/library/ubuntu': could not find image manifest
```
