### PR TITLE
Update README: use newest v0.10.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,14 +83,14 @@ With valid `source` options as such:
 
 **Ubuntu/Debian**
 ```bash
-wget https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_linux_amd64.deb
-sudo apt install ./dive_0.9.2_linux_amd64.deb
+wget https://github.com/wagoodman/dive/releases/download/v0.10.0/dive_0.10.0_linux_amd64.deb
+sudo apt install ./dive_0.10.0_linux_amd64.deb
 ```
 
 **RHEL/Centos**
 ```bash
-curl -OL https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_linux_amd64.rpm
-rpm -i dive_0.9.2_linux_amd64.rpm
+curl -OL https://github.com/wagoodman/dive/releases/download/v0.10.0/dive_0.10.0_linux_amd64.rpm
+rpm -i dive_0.10.0_linux_amd64.rpm
 ```
 
 **Arch Linux**
@@ -117,11 +117,11 @@ If you use [MacPorts](https://www.macports.org):
 sudo port install dive
 ```
 
-Or download the latest Darwin build from the [releases page](https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_darwin_amd64.tar.gz).
+Or download the latest Darwin build from the [releases page](https://github.com/wagoodman/dive/releases/download/v0.10.0/dive_0.10.0_darwin_amd64.tar.gz).
 
 **Windows**
 
-Download the [latest release](https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_windows_amd64.zip).
+Download the [latest release](https://github.com/wagoodman/dive/releases/download/v0.10.0/dive_0.10.0_windows_amd64.zip).
 
 **Go tools**
 Requires Go version 1.10 or higher.


### PR DESCRIPTION
Update the links to binaries to point to current version 0.10.0 instead of 0.9.2