### PR TITLE
Support podman in macOS

### DIFF
--- a/dive/image/podman/build.go
+++ b/dive/image/podman/build.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux darwin
 
 package podman
 

--- a/dive/image/podman/cli.go
+++ b/dive/image/podman/cli.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build linux darwin
 
 package podman
 

--- a/dive/image/podman/resolver.go
+++ b/dive/image/podman/resolver.go
@@ -1,3 +1,5 @@
+// +build linux darwin
+
 package podman
 
 import (

--- a/dive/image/podman/resolver_unsupported.go
+++ b/dive/image/podman/resolver_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux,!darwin
 
 package podman
 


### PR DESCRIPTION
With [a fix][1] in [podman v3.4.3][2], these commands now work as expected in macOS. Potentially, it might make sense to version check podman to ensure that the minimum version is met, but I'm not sure that's needed because it's unlikely that people have an older version installed _and_ wish to use this tool.

I'm unsure whether the commands work on Windows so I left the unsupported version there compiling with the negation of the supported flags.

Closes #368

[1]: https://github.com/containers/podman/issues/12402
[2]: https://github.com/containers/podman/blob/4ba71f955a944790edda6e007e6d074009d437a7/RELEASE_NOTES.md#bugfixes-2