### PR TITLE
Fix error on Layer section and reduce information on one line per step.

### DIFF
--- a/dive/image/layer.go
+++ b/dive/image/layer.go
@@ -2,6 +2,8 @@ package image
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/dustin/go-humanize"
 	"github.com/wagoodman/dive/dive/filetree"
 )
@@ -39,5 +41,5 @@ func (l *Layer) String() string {
 	}
 	return fmt.Sprintf(LayerFormat,
 		humanize.Bytes(l.Size),
-		l.Command)
+		strings.Split(l.Command, "\n")[0])
 }


### PR DESCRIPTION
When scrolling through commands in `Layers` section, in the case of multiline commands, the user could cause an index out of bounds error by scrolling to much. Here is an example:

![dive_wrong](https://user-images.githubusercontent.com/15312927/164769550-e6f91d4f-aa0c-475e-9750-03703abb5f1b.gif)

and Dockerfile used is as follows:

```
# syntax=docker/dockerfile:1.3-labs                                                                 
FROM archlinux                                                                                      
                                                                                                    
RUN <<-EOF                                                                                          
    echo "Look what they've done to my line, it's ruined! Ruined, I tell ya! Because maybe I have a wide monitor that can fit more than 50 chars so I shall not be hindered by mere mortals! 
    cd /tmp                                                                                         
    cd /                                                                                            
EOF                                                                                                 
                                                                                                    
WORKDIR /home/bajo 
```

It's hard to see, but when the user just presses down, at one point it panics from `dive.exe`.
Therefore multiline is now limited to just one line, as it also seems redundant to have the same information in `Layers` and `Layers Details` sections.