### PR TITLE
Correct installation instruction for Ubuntu/Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ With valid `source` options as such:
 
 **Ubuntu/Debian**
 ```bash
-wget https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_linux_amd64.deb
+curl -OL https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_linux_amd64.deb
 sudo apt install ./dive_0.9.2_linux_amd64.deb
 ```
 


### PR DESCRIPTION
The below command is written in README as an installation instruction for Ubuntu/Debian.

```sh
wget https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_linux_amd64.deb
```

This command creates a file whose name is not `dive_0.9.2_linux_amd64.deb` but `5db79280-4b50-11ea-8123-47efdc093285?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAIWNJYAX4CSVEH53A%2F20220509%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20220509T123525Z&X-Amz-Expires=300&X-Amz-Signature=4d880f8e576fcbd2da97348`.

It is because `https://github.com/wagoodman/dive/releases/download/v0.9.2/dive_0.9.2_linux_amd64.deb` redirects to the other URL (see the below image for more details).

<img width="1920" alt="dive_http_result" src="https://user-images.githubusercontent.com/7800796/167411813-63ed4d46-51ed-4235-bc20-0b3a314dcc15.png">

So we should use `wget -O` or `curl -OL` command instead of just `wget`.