### PR TITLE
fix(deps): bump golang.org/x/sys so that project builds on darwin arm64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.4.0 // indirect
 	golang.org/x/net v0.0.0-20190827160401-ba9fcec4b297
-	golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 // indirect
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/genproto v0.0.0-20190620144150-6af8c5fc6601 // indirect
 	google.golang.org/grpc v1.21.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -236,6 +236,8 @@ golang.org/x/sys v0.0.0-20190507160741-ecd444e8653b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4 h1:sfkvUWPNGwSV+8/fNqctR5lS2AqCSqYwXdrjCxp/dXo=
 golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a h1:dGzPydgVsqGcTRVwiLJ1jVbufYwmzD3LfVPLKsKg+0k=
+golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=


### PR DESCRIPTION
This PR addresses the following build error on darwin arm64:

```
# golang.org/x/sys/unix
../../.gvm/pkgsets/go1.18.2/global/pkg/mod/golang.org/x/sys@v0.0.0-20200212091648-12a6c2dcc1e4/unix/syscall_darwin.1_13.go:25:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.2/global/pkg/mod/golang.org/x/sys@v0.0.0-20200212091648-12a6c2dcc1e4/unix/zsyscall_darwin_arm64.1_13.go:27:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.2/global/pkg/mod/golang.org/x/sys@v0.0.0-20200212091648-12a6c2dcc1e4/unix/zsyscall_darwin_arm64.1_13.go:40:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.2/global/pkg/mod/golang.org/x/sys@v0.0.0-20200212091648-12a6c2dcc1e4/unix/zsyscall_darwin_arm64.go:28:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.2/global/pkg/mod/golang.org/x/sys@v0.0.0-20200212091648-12a6c2dcc1e4/unix/zsyscall_darwin_arm64.go:43:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.2/global/pkg/mod/golang.org/x/sys@v0.0.0-20200212091648-12a6c2dcc1e4/unix/zsyscall_darwin_arm64.go:59:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.2/global/pkg/mod/golang.org/x/sys@v0.0.0-20200212091648-12a6c2dcc1e4/unix/zsyscall_darwin_arm64.go:75:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.2/global/pkg/mod/golang.org/x/sys@v0.0.0-20200212091648-12a6c2dcc1e4/unix/zsyscall_darwin_arm64.go:90:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.2/global/pkg/mod/golang.org/x/sys@v0.0.0-20200212091648-12a6c2dcc1e4/unix/zsyscall_darwin_arm64.go:105:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.2/global/pkg/mod/golang.org/x/sys@v0.0.0-20200212091648-12a6c2dcc1e4/unix/zsyscall_darwin_arm64.go:121:3: //go:linkname must refer to declared function or variable
../../.gvm/pkgsets/go1.18.2/global/pkg/mod/golang.org/x/sys@v0.0.0-20200212091648-12a6c2dcc1e4/unix/zsyscall_darwin_arm64.go:121:3: too many errors
```