### PR TITLE
UPDATE[README.md]

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Download the [latest release](https://github.com/wagoodman/dive/releases/downloa
 Requires Go version 1.10 or higher.
 
 ```bash
-go get github.com/wagoodman/dive
+go install github.com/wagoodman/dive@latest
 ```
 *Note*: installing in this way you will not see a proper version when running `dive -v`.
 


### PR DESCRIPTION
 'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,