### PR TITLE
fix(sec): upgrade github.com/docker/docker to 1.6.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cespare/xxhash v1.1.0
 	github.com/docker/cli v0.0.0-20190906153656-016a3232168d
 	github.com/docker/distribution v2.7.1+incompatible // indirect
-	github.com/docker/docker v0.7.3-0.20190309235953-33c3200e0d16
+	github.com/docker/docker v1.6.1
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in github.com/docker/docker v0.7.3-0.20190309235953-33c3200e0d16
- [CVE-2015-3627](https://www.oscs1024.com/hd/CVE-2015-3627)


### What did I do？
Upgrade github.com/docker/docker from v0.7.3-0.20190309235953-33c3200e0d16 to 1.6.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS