### PR TITLE
feat: add support for alternative ordering strategies

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -86,6 +86,7 @@ func initConfig() {
 	// keybindings: filetree view
 	viper.SetDefault("keybinding.toggle-collapse-dir", "space")
 	viper.SetDefault("keybinding.toggle-collapse-all-dir", "ctrl+space")
+	viper.SetDefault("keybinding.toggle-sort-order", "ctrl+o")
 	viper.SetDefault("keybinding.toggle-filetree-attributes", "ctrl+b")
 	viper.SetDefault("keybinding.toggle-added-files", "ctrl+a")
 	viper.SetDefault("keybinding.toggle-removed-files", "ctrl+r")

--- a/dive/filetree/efficiency.go
+++ b/dive/filetree/efficiency.go
@@ -79,7 +79,7 @@ func Efficiency(trees []*FileTree) (float64, EfficiencySlice) {
 			}
 
 			if previousTreeNode.Data.FileInfo.IsDir {
-				err = previousTreeNode.VisitDepthChildFirst(sizer, nil)
+				err = previousTreeNode.VisitDepthChildFirst(sizer, nil, nil)
 				if err != nil {
 					logrus.Errorf("unable to propagate whiteout dir: %+v", err)
 					return err

--- a/dive/filetree/order_strategy.go
+++ b/dive/filetree/order_strategy.go
@@ -1,0 +1,61 @@
+package filetree
+
+import (
+	"sort"
+)
+
+type SortOrder int
+
+const (
+	ByName = iota
+	BySizeDesc
+
+	NumSortOrderConventions
+)
+
+type OrderStrategy interface {
+	orderKeys(files map[string]*FileNode) []string
+}
+
+func GetSortOrderStrategy(sortOrder SortOrder) OrderStrategy {
+	switch sortOrder {
+	case ByName:
+		return orderByNameStrategy{}
+	case BySizeDesc:
+		return orderBySizeDescStrategy{}
+	}
+	return orderByNameStrategy{}
+}
+
+type orderByNameStrategy struct{}
+
+func (orderByNameStrategy) orderKeys(files map[string]*FileNode) []string {
+	var keys []string
+	for key := range files {
+		keys = append(keys, key)
+	}
+
+	sort.Strings(keys)
+
+	return keys
+}
+
+type orderBySizeDescStrategy struct{}
+
+func (orderBySizeDescStrategy) orderKeys(files map[string]*FileNode) []string {
+	var keys []string
+	for key := range files {
+		keys = append(keys, key)
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		ki, kj := keys[i], keys[j]
+		ni, nj := files[ki], files[kj]
+		if ni.GetSize() == nj.GetSize() {
+			return ki < kj
+		}
+		return ni.GetSize() > nj.GetSize()
+	})
+
+	return keys
+}

--- a/runtime/ui/view/filetree.go
+++ b/runtime/ui/view/filetree.go
@@ -24,7 +24,7 @@ type FileTree struct {
 	gui    *gocui.Gui
 	view   *gocui.View
 	header *gocui.View
-	vm     *viewmodel.FileTree
+	vm     *viewmodel.FileTreeViewModel
 	title  string
 
 	filterRegex         *regexp.Regexp
@@ -97,6 +97,11 @@ func (v *FileTree) Setup(view, header *gocui.View) error {
 			ConfigKeys: []string{"keybinding.toggle-collapse-all-dir"},
 			OnAction:   v.toggleCollapseAll,
 			Display:    "Collapse all dir",
+		},
+		{
+			ConfigKeys: []string{"keybinding.toggle-sort-order"},
+			OnAction:   v.toggleSortOrder,
+			Display:    "Toggle sort order",
 		},
 		{
 			ConfigKeys: []string{"keybinding.toggle-added-files"},
@@ -284,6 +289,16 @@ func (v *FileTree) toggleCollapseAll() error {
 	if v.vm.CollapseAll {
 		v.resetCursor()
 	}
+	_ = v.Update()
+	return v.Render()
+}
+
+func (v *FileTree) toggleSortOrder() error {
+	err := v.vm.ToggleSortOrder()
+	if err != nil {
+		return err
+	}
+	v.resetCursor()
 	_ = v.Update()
 	return v.Render()
 }

--- a/runtime/ui/viewmodel/filetree_test.go
+++ b/runtime/ui/viewmodel/filetree_test.go
@@ -73,7 +73,7 @@ func assertTestData(t *testing.T, actualBytes []byte) {
 	helperCheckDiff(t, expectedBytes, actualBytes)
 }
 
-func initializeTestViewModel(t *testing.T) *FileTree {
+func initializeTestViewModel(t *testing.T) *FileTreeViewModel {
 	result := docker.TestAnalysisFromArchive(t, "../../../.data/test-docker-image.tar")
 
 	cache := filetree.NewComparer(result.RefTrees)
@@ -98,7 +98,7 @@ func initializeTestViewModel(t *testing.T) *FileTree {
 	return vm
 }
 
-func runTestCase(t *testing.T, vm *FileTree, width, height int, filterRegex *regexp.Regexp) {
+func runTestCase(t *testing.T, vm *FileTreeViewModel, width, height int, filterRegex *regexp.Regexp) {
 	err := vm.Update(filterRegex, width, height)
 	if err != nil {
 		t.Errorf("failed to update viewmodel: %v", err)


### PR DESCRIPTION
Addresses https://github.com/wagoodman/dive/issues/341.

Adds a default hotkey of `ctrl+o` to flip between A-Z sort order and numerical sort-by-size-desc on the right-side pane.

The approach to implementing this feature was to find all of the places in code that enforce the *order* in which file-system nodes in the selected layer are displayed in the buffer window. Three methods were identified: `FileTree.StringBetween`, `FileNode.VisitDepthParentFirst` and `FileNode.VisitDepthChildFirst`. These locations were taking the `FileNode`'s property `Children map[string]*FileNode` and performing `sort.Strings(keys)` in order to implement alphanumeric sorting. 

These locations have been unified with `OrderStrategy.orderKeys(map[string]*FileNode)`. A factory function, `GetSortOrderStrategy`, tees up the corresponding ordering strategy given an enum, which it then propagates down to the three mentioned methods.

Additionally, a `Size int64` field has been attached to `FileNode` in order to cache information on directory/file size for use in the sort-by-size-desc strategy (with a simple extraction refactor of the `FileNode.MetadataString` method.

Happy New Year! 🥂 