### PR TITLE
Updated the deprecated ioutil dependency

### DIFF
--- a/cmd/ci.go
+++ b/cmd/ci.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 
@@ -21,7 +20,7 @@ func configureCi() (bool, *viper.Viper, error) {
 		if _, err := os.Stat(ciConfigFile); !os.IsNotExist(err) {
 			fmt.Printf("  Using CI config: %s\n", ciConfigFile)
 
-			fileBytes, err := ioutil.ReadFile(ciConfigFile)
+			fileBytes, err := os.ReadFile(ciConfigFile)
 			if err != nil {
 				return isCi, nil, err
 			}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"strings"
@@ -146,7 +146,7 @@ func initLogging() {
 		logFileObj, err = os.OpenFile(viper.GetString("log.path"), os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0644)
 		log.SetOutput(logFileObj)
 	} else {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 
 	if err != nil {
@@ -198,7 +198,7 @@ func getDefaultCfgFile() string {
 // if not found returns empty string
 func findInPath(pathTo string) string {
 	directory := path.Join(pathTo, "dive")
-	files, err := ioutil.ReadDir(directory)
+	files, err := os.ReadDir(directory)
 	if err != nil {
 		return ""
 	}

--- a/dive/image/docker/build.go
+++ b/dive/image/docker/build.go
@@ -1,12 +1,11 @@
 package docker
 
 import (
-	"io/ioutil"
 	"os"
 )
 
 func buildImageFromCli(buildArgs []string) (string, error) {
-	iidfile, err := ioutil.TempFile("/tmp", "dive.*.iid")
+	iidfile, err := os.CreateTemp("/tmp", "dive.*.iid")
 	if err != nil {
 		return "", err
 	}
@@ -18,7 +17,7 @@ func buildImageFromCli(buildArgs []string) (string, error) {
 		return "", err
 	}
 
-	imageId, err := ioutil.ReadFile(iidfile.Name())
+	imageId, err := os.ReadFile(iidfile.Name())
 	if err != nil {
 		return "", err
 	}

--- a/dive/image/docker/image_archive.go
+++ b/dive/image/docker/image_archive.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -81,7 +80,7 @@ func NewImageArchive(tarFile io.ReadCloser) (*ImageArchive, error) {
 				img.layerMap[tree.Name] = tree
 
 			} else if strings.HasSuffix(name, ".json") || strings.HasPrefix(name, "sha256:") {
-				fileBuffer, err := ioutil.ReadAll(tarReader)
+				fileBuffer, err := io.ReadAll(tarReader)
 				if err != nil {
 					return img, err
 				}

--- a/dive/image/podman/build.go
+++ b/dive/image/podman/build.go
@@ -3,12 +3,11 @@
 package podman
 
 import (
-	"io/ioutil"
 	"os"
 )
 
 func buildImageFromCli(buildArgs []string) (string, error) {
-	iidfile, err := ioutil.TempFile("/tmp", "dive.*.iid")
+	iidfile, err := os.CreateTemp("/tmp", "dive.*.iid")
 	if err != nil {
 		return "", err
 	}
@@ -20,7 +19,7 @@ func buildImageFromCli(buildArgs []string) (string, error) {
 		return "", err
 	}
 
-	imageId, err := ioutil.ReadFile(iidfile.Name())
+	imageId, err := os.ReadFile(iidfile.Name())
 	if err != nil {
 		return "", err
 	}

--- a/dive/image/podman/resolver.go
+++ b/dive/image/podman/resolver.go
@@ -4,9 +4,9 @@ package podman
 
 import (
 	"fmt"
+	"io"
 	"github.com/wagoodman/dive/dive/image"
 	"github.com/wagoodman/dive/dive/image/docker"
-	"io/ioutil"
 )
 
 type resolver struct{}
@@ -40,7 +40,7 @@ func (r *resolver) resolveFromDockerArchive(id string) (*image.Image, error) {
 		return nil, err
 	}
 
-	img, err := docker.NewImageArchive(ioutil.NopCloser(reader))
+	img, err := docker.NewImageArchive(io.NopCloser(reader))
 	if err != nil {
 		return nil, err
 	}

--- a/runtime/ui/viewmodel/filetree_test.go
+++ b/runtime/ui/viewmodel/filetree_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"github.com/wagoodman/dive/dive/image/docker"
 	"github.com/wagoodman/dive/runtime/ui/format"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -31,7 +30,7 @@ func testCaseDataFilePath(name string) string {
 
 func helperLoadBytes(t *testing.T) []byte {
 	path := testCaseDataFilePath(t.Name())
-	theBytes, err := ioutil.ReadFile(path)
+	theBytes, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatalf("unable to load test data ('%s'): %+v", t.Name(), err)
 	}
@@ -44,7 +43,7 @@ func helperCaptureBytes(t *testing.T, data []byte) {
 	}
 
 	path := testCaseDataFilePath(t.Name())
-	err := ioutil.WriteFile(path, data, 0644)
+	err := os.WriteFile(path, data, 0644)
 
 	if err != nil {
 		t.Fatalf("unable to save test data ('%s'): %+v", t.Name(), err)


### PR DESCRIPTION
The ioutil package has been deprecated as of Go v1.16: https://go.dev/doc/go1.16#ioutil

This commit replaces ioutil functions with their respective io/os functions.