### PR TITLE
add note about default socket to macos installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ sudo port install dive
 
 Or download the latest Darwin build from the [releases page](https://github.com/wagoodman/dive/releases/latest).
 
+*Note*: If using Docker Desktop for MacOS, dive requires the default Docker socket to be available at `/var/run/docker.sock`. You can enable it at `Settings > Advanced > Allow the default Docker socket to be used`.
+
 **Windows**
 
 Download the [latest release](https://github.com/wagoodman/dive/releases/latest).


### PR DESCRIPTION
This note should resolve https://github.com/wagoodman/dive/issues/462 - and basically addresses the use case where MacOS users don't have the default socket option enabled in Docker Desktop - causing the (somewhat ambiguous) error `Error response from daemon: pull access denied`

**Edit**
and also resolve https://github.com/wagoodman/dive/issues/453

