### PR TITLE
Fix scrolling after gocui update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.18
 
 ARG DOCKER_CLI_VERSION=${DOCKER_CLI_VERSION}
 RUN wget -O- https://download.docker.com/linux/static/stable/$(uname -m)/docker-${DOCKER_CLI_VERSION}.tgz | \

--- a/runtime/ui/view/cursor.go
+++ b/runtime/ui/view/cursor.go
@@ -1,38 +1,17 @@
 package view
 
 import (
-	"errors"
-
 	"github.com/awesome-gocui/gocui"
 )
 
 // CursorDown moves the cursor down in the currently selected gocui pane, scrolling the screen as needed.
-func CursorDown(g *gocui.Gui, v *gocui.View) error {
-	return CursorStep(g, v, 1)
+func CursorDown(v *gocui.View, step uint) error {
+	v.MoveCursor(0, int(step))
+	return nil
 }
 
 // CursorUp moves the cursor up in the currently selected gocui pane, scrolling the screen as needed.
-func CursorUp(g *gocui.Gui, v *gocui.View) error {
-	return CursorStep(g, v, -1)
-}
-
-// Moves the cursor the given step distance, setting the origin to the new cursor line
-func CursorStep(g *gocui.Gui, v *gocui.View, step int) error {
-	cx, cy := v.Cursor()
-
-	// if there isn't a next line
-	line, err := v.Line(cy + step)
-	if err != nil {
-		return err
-	}
-	if len(line) == 0 {
-		return errors.New("unable to move the cursor, empty line")
-	}
-	if err := v.SetCursor(cx, cy+step); err != nil {
-		ox, oy := v.Origin()
-		if err := v.SetOrigin(ox, oy+step); err != nil {
-			return err
-		}
-	}
+func CursorUp(v *gocui.View, step uint) error {
+	v.MoveCursor(0, int(-step))
 	return nil
 }

--- a/runtime/ui/view/image_details.go
+++ b/runtime/ui/view/image_details.go
@@ -136,32 +136,20 @@ func (v *ImageDetails) IsVisible() bool {
 
 func (v *ImageDetails) PageUp() error {
 	_, height := v.body.Size()
-	if err := CursorStep(v.gui, v.body, -height); err != nil {
-		logrus.Debugf("Couldn't move the cursor up by %d steps", height)
-	}
-	return nil
+	return CursorUp(v.body, uint(height))
 }
 
 func (v *ImageDetails) PageDown() error {
 	_, height := v.body.Size()
-	if err := CursorStep(v.gui, v.body, height); err != nil {
-		logrus.Debugf("Couldn't move the cursor down by %d steps", height)
-	}
-	return nil
+	return CursorDown(v.body, uint(height))
 }
 
 func (v *ImageDetails) CursorUp() error {
-	if err := CursorUp(v.gui, v.body); err != nil {
-		logrus.Debug("Couldn't move the cursor up")
-	}
-	return nil
+	return CursorUp(v.body, 1)
 }
 
 func (v *ImageDetails) CursorDown() error {
-	if err := CursorDown(v.gui, v.body); err != nil {
-		logrus.Debug("Couldn't move the cursor down")
-	}
-	return nil
+	return CursorDown(v.body, 1)
 }
 
 // KeyHelp indicates all the possible actions a user can take while the current pane is selected (currently does nothing).

--- a/runtime/ui/view/layer_details.go
+++ b/runtime/ui/view/layer_details.go
@@ -113,18 +113,12 @@ func (v *LayerDetails) IsVisible() bool {
 
 // CursorUp moves the cursor up in the details pane
 func (v *LayerDetails) CursorUp() error {
-	if err := CursorUp(v.gui, v.body); err != nil {
-		logrus.Debug("Couldn't move the cursor up")
-	}
-	return nil
+	return CursorUp(v.body, 1)
 }
 
 // CursorDown moves the cursor up in the details pane
 func (v *LayerDetails) CursorDown() error {
-	if err := CursorDown(v.gui, v.body); err != nil {
-		logrus.Debug("Couldn't move the cursor down")
-	}
-	return nil
+	return CursorDown(v.body, 1)
 }
 
 // KeyHelp indicates all the possible actions a user can take while the current pane is selected (currently does nothing).

--- a/runtime/ui/viewmodel/layer_set_state.go
+++ b/runtime/ui/viewmodel/layer_set_state.go
@@ -65,7 +65,7 @@ func (vm *LayerSetState) PageUp() bool {
 		vm.LayerIndex = 0
 		prevPageEndIndex = vm.viewHeight
 		if prevPageEndIndex >= len(vm.Layers) {
-			return false
+			return true
 		}
 	}
 

--- a/runtime/ui/viewmodel/layer_set_state.go
+++ b/runtime/ui/viewmodel/layer_set_state.go
@@ -1,19 +1,187 @@
 package viewmodel
 
-import "github.com/wagoodman/dive/dive/image"
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/wagoodman/dive/dive/image"
+	"github.com/wagoodman/dive/runtime/ui/format"
+)
 
 type LayerSetState struct {
 	LayerIndex        int
 	Layers            []*image.Layer
 	CompareMode       LayerCompareMode
 	CompareStartIndex int
+
+	constrainedRealEstate bool
+	viewStartIndex int
+	viewHeight     int
+
+	Buffer bytes.Buffer
 }
 
 func NewLayerSetState(layers []*image.Layer, compareMode LayerCompareMode) *LayerSetState {
 	return &LayerSetState{
 		Layers:      layers,
 		CompareMode: compareMode,
+		LayerIndex:     0,
+		viewStartIndex: 0,
 	}
+}
+
+// Setup initializes the UI concerns within the context of a global [gocui] view object.
+func (vm *LayerSetState) Setup(lowerBound, height int) {
+	vm.viewStartIndex = lowerBound
+	vm.viewHeight = height
+}
+
+// height returns the current height and considers the header
+func (vm *LayerSetState) height() int {
+	return vm.viewHeight - 1
+}
+
+// IsVisible indicates if the layer view pane is currently initialized
+func (vm *LayerSetState) IsVisible() bool {
+	return vm != nil
+}
+
+// ResetCursor moves the cursor back to the top of the buffer and translates to the top of the buffer.
+func (vm *LayerSetState) ResetCursor() {
+	vm.LayerIndex = 0
+	vm.viewStartIndex = 0
+}
+
+
+// PageUp moves to previous page putting the cursor on top
+func (vm *LayerSetState) PageUp() bool {
+	prevPageEndIndex := vm.viewStartIndex
+	prevPageStartIndex := vm.viewStartIndex - vm.viewHeight + 1
+
+	if prevPageStartIndex < 0 {
+		prevPageStartIndex = 0
+		vm.LayerIndex = 0
+		prevPageEndIndex = vm.viewHeight
+		if prevPageEndIndex >= len(vm.Layers) {
+			return false
+		}
+	}
+
+	vm.viewStartIndex = prevPageStartIndex
+
+	if vm.LayerIndex >= prevPageEndIndex {
+		vm.LayerIndex = prevPageEndIndex
+	}
+	return true
+}
+
+// PageDown moves to next page putting the cursor on top
+func (vm *LayerSetState) PageDown() bool {
+	nextPageStartIndex := vm.viewStartIndex + vm.viewHeight - 1
+	nextPageEndIndex := nextPageStartIndex + vm.viewHeight
+
+	if nextPageEndIndex > len(vm.Layers) {
+		nextPageEndIndex = len(vm.Layers) - 1
+		vm.LayerIndex = nextPageEndIndex
+		nextPageStartIndex = nextPageEndIndex - vm.viewHeight + 1
+		if (nextPageStartIndex < 0) {
+			return false
+		}
+	}
+
+	vm.viewStartIndex = nextPageStartIndex
+
+	if vm.LayerIndex < nextPageStartIndex {
+		vm.LayerIndex = nextPageStartIndex
+	}
+	
+	return true
+}
+
+// doCursorUp performs the internal view's adjustments on cursor up. Note: this is independent of the gocui buffer.
+func (vm *LayerSetState) CursorUp() bool {
+	if vm.LayerIndex <= 0 {
+		return false
+	}
+	vm.LayerIndex--
+	if vm.LayerIndex < vm.viewStartIndex {
+		vm.viewStartIndex--
+	}
+	return true
+}
+
+// doCursorDown performs the internal view's adjustments on cursor down. Note: this is independent of the gocui buffer.
+func (vm *LayerSetState) CursorDown() bool {
+	if vm.LayerIndex >= len(vm.Layers) - 1 {
+		return false
+	}
+	vm.LayerIndex++
+	if vm.LayerIndex >= vm.viewStartIndex + vm.viewHeight {
+		vm.viewStartIndex++
+	}
+	return true
+}
+
+// renderCompareBar returns the formatted string for the given layer.
+func (vm *LayerSetState) renderCompareBar(layerIdx int) string {
+	bottomTreeStart, bottomTreeStop, topTreeStart, topTreeStop := vm.GetCompareIndexes()
+	result := "  "
+
+	if layerIdx >= bottomTreeStart && layerIdx <= bottomTreeStop {
+		result = format.CompareBottom("  ")
+	}
+	if layerIdx >= topTreeStart && layerIdx <= topTreeStop {
+		result = format.CompareTop("  ")
+	}
+
+	return result
+}
+
+// Update refreshes the state objects for future rendering
+func (vm *LayerSetState) Update(isConstrainedRealEstate bool) error {
+	vm.constrainedRealEstate = isConstrainedRealEstate
+	return nil
+}
+
+// Render flushes the state objects to the screen. The layers pane reports:
+// 1. the layers of the image surrounding the currently selected layer
+// 2. the current selected layer
+func (vm *LayerSetState) Render() error {
+	logrus.Tracef("viewmodel.LayerSetState.Render() %s", vm.Layers[vm.LayerIndex].Id)
+
+	// write contents of pane
+	vm.Buffer.Reset()
+	for idx, layer := range vm.Layers {
+		if idx < vm.viewStartIndex {
+			continue
+		}
+		if idx > vm.viewStartIndex + vm.viewHeight {
+			break
+		}
+		var layerStr string
+		if vm.constrainedRealEstate {
+			layerStr = fmt.Sprintf("%-4d", layer.Index)
+		} else {
+			layerStr = layer.String()
+		}
+
+		compareBar := vm.renderCompareBar(idx)
+
+		err := error(nil)
+		if idx == vm.LayerIndex {
+			_, err = fmt.Fprintln(&vm.Buffer, compareBar+" "+format.Selected(layerStr))
+		} else {
+			_, err = fmt.Fprintln(&vm.Buffer, compareBar+" "+layerStr)
+		}
+
+		if err != nil {
+			logrus.Debug("unable to write to buffer: ", err)
+			return err
+		}
+	}
+	return nil
 }
 
 // getCompareIndexes determines the layer boundaries to use for comparison (based on the current compare mode)

--- a/runtime/ui/viewmodel/layer_set_state.go
+++ b/runtime/ui/viewmodel/layer_set_state.go
@@ -17,16 +17,16 @@ type LayerSetState struct {
 	CompareStartIndex int
 
 	constrainedRealEstate bool
-	viewStartIndex int
-	viewHeight     int
+	viewStartIndex        int
+	viewHeight            int
 
 	Buffer bytes.Buffer
 }
 
 func NewLayerSetState(layers []*image.Layer, compareMode LayerCompareMode) *LayerSetState {
 	return &LayerSetState{
-		Layers:      layers,
-		CompareMode: compareMode,
+		Layers:         layers,
+		CompareMode:    compareMode,
 		LayerIndex:     0,
 		viewStartIndex: 0,
 	}
@@ -53,7 +53,6 @@ func (vm *LayerSetState) ResetCursor() {
 	vm.LayerIndex = 0
 	vm.viewStartIndex = 0
 }
-
 
 // PageUp moves to previous page putting the cursor on top
 func (vm *LayerSetState) PageUp() bool {
@@ -86,7 +85,7 @@ func (vm *LayerSetState) PageDown() bool {
 		nextPageEndIndex = len(vm.Layers) - 1
 		vm.LayerIndex = nextPageEndIndex
 		nextPageStartIndex = nextPageEndIndex - vm.viewHeight + 1
-		if (nextPageStartIndex < 0) {
+		if nextPageStartIndex < 0 {
 			return false
 		}
 	}
@@ -96,7 +95,7 @@ func (vm *LayerSetState) PageDown() bool {
 	if vm.LayerIndex < nextPageStartIndex {
 		vm.LayerIndex = nextPageStartIndex
 	}
-	
+
 	return true
 }
 
@@ -114,11 +113,11 @@ func (vm *LayerSetState) CursorUp() bool {
 
 // doCursorDown performs the internal view's adjustments on cursor down. Note: this is independent of the gocui buffer.
 func (vm *LayerSetState) CursorDown() bool {
-	if vm.LayerIndex >= len(vm.Layers) - 1 {
+	if vm.LayerIndex >= len(vm.Layers)-1 {
 		return false
 	}
 	vm.LayerIndex++
-	if vm.LayerIndex >= vm.viewStartIndex + vm.viewHeight {
+	if vm.LayerIndex >= vm.viewStartIndex+vm.viewHeight {
 		vm.viewStartIndex++
 	}
 	return true
@@ -157,7 +156,7 @@ func (vm *LayerSetState) Render() error {
 		if idx < vm.viewStartIndex {
 			continue
 		}
-		if idx > vm.viewStartIndex + vm.viewHeight {
+		if idx > vm.viewStartIndex+vm.viewHeight {
 			break
 		}
 		var layerStr string


### PR DESCRIPTION
This fixes the scrolling caused by a regression in #447 .

It still has some issues regarding highlighting rows, but I'm not overtly interested in diving into `gocui` given that it's not actively maintained. At least it enables the user to scroll again.

Fixes #540
Fixes #494 
Fixes #469