### PR TITLE
Fix debian package installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ With valid `source` options as such:
 ```bash
 export DIVE_VERSION=$(curl -sL "https://api.github.com/repos/wagoodman/dive/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
 curl -OL https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_amd64.deb
-sudo apt install ./dive_${DIVE_VERSION}_linux_amd64.deb
+sudo dokg -i ./dive_${DIVE_VERSION}_linux_amd64.deb
 ```
 
 **RHEL/Centos**


### PR DESCRIPTION
The correct command to run is `dpkg -i` on a debian package file. The instructions said to use `apt install` which does not work to install from a file.