### PR TITLE
[Vulnerabilities] Update Dockerfile Alpine Image from alpine:3.12 => alpine:3.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.12
+FROM alpine:3.18
 
 ARG DOCKER_CLI_VERSION=${DOCKER_CLI_VERSION}
 RUN wget -O- https://download.docker.com/linux/static/stable/$(uname -m)/docker-${DOCKER_CLI_VERSION}.tgz | \


### PR DESCRIPTION
Hi, I am proposing an upgrade of the alpine image to patch discovered vulnerabilities.
Trivy Report showing vunlarability:

WARN	This OS version is no longer supported by the distribution: alpine 3.12.12
│ zlib    │ CVE-2022-37434 │ CRITICAL │ fixed  │ 1.2.12-r0         │ 1.2.12-r2     |
https://avd.aquasec.com/nvd/cve-2022-37434