### PR TITLE
docs: Adds instructions for snap installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,20 @@ With valid `source` options as such:
 ## Installation
 
 **Ubuntu/Debian**
+
+Using debs:
 ```bash
 export DIVE_VERSION=$(curl -sL "https://api.github.com/repos/wagoodman/dive/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
 curl -OL https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_amd64.deb
 sudo apt install ./dive_${DIVE_VERSION}_linux_amd64.deb
+```
+
+Using snap:
+```bash
+sudo snap install docker
+sudo snap install dive
+sudo snap connect dive:docker-executables docker:docker-executables
+sudo snap connect dive:docker-daemon docker:docker-daemon
 ```
 
 **RHEL/Centos**


### PR DESCRIPTION
## Description

This PR adds instructions for installing the dive snap.

## Reference
- https://snapcraft.io/dive
- https://github.com/gruyaume/dive-snap