### PR TITLE
DIVE_VERSION does not need to be exported

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,14 @@ With valid `source` options as such:
 
 **Ubuntu/Debian**
 ```bash
-export DIVE_VERSION=$(curl -sL "https://api.github.com/repos/wagoodman/dive/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+DIVE_VERSION=$(curl -sL "https://api.github.com/repos/wagoodman/dive/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
 curl -OL https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_amd64.deb
 sudo apt install ./dive_${DIVE_VERSION}_linux_amd64.deb
 ```
 
 **RHEL/Centos**
 ```bash
-export DIVE_VERSION=$(curl -sL "https://api.github.com/repos/wagoodman/dive/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
+DIVE_VERSION=$(curl -sL "https://api.github.com/repos/wagoodman/dive/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
 curl -OL https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_amd64.rpm
 rpm -i dive_${DIVE_VERSION}_linux_amd64.rpm
 ```


### PR DESCRIPTION
The value of the variable DIVE_VERSION is not needed in a spawned subprocess. Thus, the variable does not necessarily need to be exported. Arguably, the environment is less polluted if it is not exported.