### PR TITLE
Fix issue #496 Line wrap toggle does not update the status bar indicator

### DIFF
--- a/runtime/ui/view/filetree.go
+++ b/runtime/ui/view/filetree.go
@@ -305,7 +305,18 @@ func (v *FileTree) toggleSortOrder() error {
 
 func (v *FileTree) toggleWrapTree() error {
 	v.view.Wrap = !v.view.Wrap
-	return nil
+
+	err := v.Update()
+	if err != nil {
+		return err
+	}
+	err = v.Render()
+	if err != nil {
+		return err
+	}
+
+	// we need to render the changes to the status pane as well (not just this contoller/view)
+	return v.notifyOnViewOptionChangeListeners()
 }
 
 func (v *FileTree) notifyOnViewOptionChangeListeners() error {


### PR DESCRIPTION
With this patch the status indicator does now change (see attachment)
![dive-wrap-status-is-now-updating](https://github.com/wagoodman/dive/assets/152920539/d1ce73eb-f4af-40b2-a02c-aba427c7784d)

Fixes #496