### PR TITLE
Update the install command to the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Download the [latest release](https://github.com/wagoodman/dive/releases/latest)
 Requires Go version 1.10 or higher.
 
 ```bash
-go get github.com/wagoodman/dive
+go install github.com/wagoodman/dive@latest
 ```
 *Note*: installing in this way you will not see a proper version when running `dive -v`.
 


### PR DESCRIPTION
`go get` no longer works with recent versions of `go`.