### PR TITLE
Fix OCI format, GZIP files can be smaller than 1024 bytes

### DIFF
--- a/dive/image/docker/image_archive.go
+++ b/dive/image/docker/image_archive.go
@@ -101,27 +101,25 @@ func NewImageArchive(tarFile io.ReadCloser) (*ImageArchive, error) {
 					return img, err
 				}
 
-				// Only try reading a TAR if file is "big enough"
-				if n == cap(buffer) {
-					var unwrappedReader io.Reader
-					unwrappedReader, err = gzip.NewReader(io.MultiReader(bytes.NewReader(buffer[:n]), tarReader))
-					if err != nil {
-						// Not a gzipped entry
-						unwrappedReader = io.MultiReader(bytes.NewReader(buffer[:n]), tarReader)
-					}
-
-					// Try reading a TAR
-					layerReader := tar.NewReader(unwrappedReader)
-					tree, err := processLayerTar(name, layerReader)
-					if err == nil {
-						currentLayer++
-						// add the layer to the image
-						img.layerMap[tree.Name] = tree
-						continue
-					}
+				// Try reading a GZIP
+				var unwrappedReader io.Reader
+				unwrappedReader, err = gzip.NewReader(io.MultiReader(bytes.NewReader(buffer[:n]), tarReader))
+				if err != nil {
+					// Not a gzipped entry
+					unwrappedReader = io.MultiReader(bytes.NewReader(buffer[:n]), tarReader)
 				}
 
-				// Not a TAR (or smaller than our buffer), might be a JSON file
+				// Try reading a TAR
+				layerReader := tar.NewReader(unwrappedReader)
+				tree, err := processLayerTar(name, layerReader)
+				if err == nil {
+					currentLayer++
+					// add the layer to the image
+					img.layerMap[tree.Name] = tree
+					continue
+				}
+
+				// Not a TAR or GZIP, might be a JSON file
 				decoder := json.NewDecoder(bytes.NewReader(buffer[:n]))
 				token, err := decoder.Token()
 				if _, ok := token.(json.Delim); err == nil && ok {


### PR DESCRIPTION
Here is a simple fix for the OCI format. When debugging I found that the GZIP size can be less than 1024 bytes when using containerd to pull the image.

I have tested with and without the "Use containerd for pulling and storing images" option in docker desktop and it appears to have fixed the issue. I also noticed issue #507 and downloading the example file it appears to resolve this issue also.

Fixes #510 
Fixes #507 
Fixes #534