### PR TITLE
fixed installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Download the [latest release](https://github.com/wagoodman/dive/releases/latest)
 Requires Go version 1.10 or higher.
 
 ```bash
-go get github.com/wagoodman/dive
+ go install github.com/wagoodman/dive@latest
 ```
 *Note*: installing in this way you will not see a proper version when running `dive -v`.
 


### PR DESCRIPTION
The command `go get` wont install dive, instead you have to use `go install`.

```bash
> go get github.com/wagoodman/dive
go: go.mod file not found in current directory or any parent directory.
        'go get' is no longer supported outside a module.
        To build and install a command, use 'go install' with a version,
        like 'go install example.com/cmd@latest'
        For more information, see https://golang.org/doc/go-get-install-deprecation
        or run 'go help get' or 'go help install'.
```