### PR TITLE
Fix typos

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -67,7 +67,7 @@ linters-settings:
 #    - prealloc     # following this rule isn't consistently a good idea, as it sometimes forces unnecessary allocations that result in less idiomatic code
 #    - scopelint    # deprecated
 #    - testpackage
-#    - wsl          # this doens't have an auto-fixer yet and is pretty noisy (https://github.com/bombsimon/wsl/issues/90)
+#    - wsl          # this doesn't have an auto-fixer yet and is pretty noisy (https://github.com/bombsimon/wsl/issues/90)
 #    - varcheck     # deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
 #    - deadcode     # deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.
 #    - structcheck  # deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter.  Replaced by unused.

--- a/Makefile
+++ b/Makefile
@@ -315,9 +315,8 @@ clean-changelog:
 	rm -f $(CHANGELOG) VERSION
 
 
-## Halp! #################################
+## Help! #################################
 
 .PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "$(BOLD)$(CYAN)%-25s$(RESET)%s\n", $$1, $$2}'
-

--- a/dive/filetree/efficiency_test.go
+++ b/dive/filetree/efficiency_test.go
@@ -10,7 +10,7 @@ func checkError(t *testing.T, err error, message string) {
 	}
 }
 
-func TestEfficency(t *testing.T) {
+func TestEfficiency(t *testing.T) {
 	trees := make([]*FileTree, 3)
 	for idx := range trees {
 		trees[idx] = NewFileTree()
@@ -56,7 +56,7 @@ func TestEfficency(t *testing.T) {
 	}
 }
 
-func TestEfficency_ScratchImage(t *testing.T) {
+func TestEfficiency_ScratchImage(t *testing.T) {
 	trees := make([]*FileTree, 3)
 	for idx := range trees {
 		trees[idx] = NewFileTree()

--- a/dive/filetree/node_data_test.go
+++ b/dive/filetree/node_data_test.go
@@ -21,13 +21,13 @@ func TestMergeDiffTypes(t *testing.T) {
 	b := Unmodified
 	merged := a.merge(b)
 	if merged != Unmodified {
-		t.Errorf("Expected Unchaged (0) but got %v", merged)
+		t.Errorf("Expected Unchanged (0) but got %v", merged)
 	}
 	a = Modified
 	b = Unmodified
 	merged = a.merge(b)
 	if merged != Modified {
-		t.Errorf("Expected Unchaged (0) but got %v", merged)
+		t.Errorf("Expected Unchanged (0) but got %v", merged)
 	}
 }
 

--- a/runtime/ui/layout/compound/layer_details_column.go
+++ b/runtime/ui/layout/compound/layer_details_column.go
@@ -72,7 +72,7 @@ func (cl *LayerDetailsCompoundLayout) layoutRow(g *gocui.Gui, minX, minY, maxX, 
 }
 
 func (cl *LayerDetailsCompoundLayout) Layout(g *gocui.Gui, minX, minY, maxX, maxY int) error {
-	logrus.Tracef("LayerDetailsCompountLayout.Layout(minX: %d, minY: %d, maxX: %d, maxY: %d) %s", minX, minY, maxX, maxY, cl.Name())
+	logrus.Tracef("LayerDetailsCompoundLayout.Layout(minX: %d, minY: %d, maxX: %d, maxY: %d) %s", minX, minY, maxX, maxY, cl.Name())
 
 	layouts := []view.IView{
 		cl.layer,

--- a/runtime/ui/view/filetree.go
+++ b/runtime/ui/view/filetree.go
@@ -335,7 +335,7 @@ func (v *FileTree) toggleAttributes() error {
 		return err
 	}
 
-	// we need to render the changes to the status pane as well (not just this contoller/view)
+	// we need to render the changes to the status pane as well (not just this controller/view)
 	return v.notifyOnViewOptionChangeListeners()
 }
 
@@ -352,7 +352,7 @@ func (v *FileTree) toggleShowDiffType(diffType filetree.DiffType) error {
 		return err
 	}
 
-	// we need to render the changes to the status pane as well (not just this contoller/view)
+	// we need to render the changes to the status pane as well (not just this controller/view)
 	return v.notifyOnViewOptionChangeListeners()
 }
 


### PR DESCRIPTION
Found via `codespell -L ot,te` and `typos --hidden --format brief`