### PR TITLE
docs(readme): update curl commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ With valid `source` options as such:
 Using debs:
 ```bash
 DIVE_VERSION=$(curl -sL "https://api.github.com/repos/wagoodman/dive/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-curl -OL https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_amd64.deb
+curl -fOL "https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_amd64.deb"
 sudo apt install ./dive_${DIVE_VERSION}_linux_amd64.deb
 ```
 
@@ -113,7 +113,7 @@ sudo snap connect dive:docker-daemon docker:docker-daemon
 **RHEL/Centos**
 ```bash
 DIVE_VERSION=$(curl -sL "https://api.github.com/repos/wagoodman/dive/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
-curl -OL https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_amd64.rpm
+curl -fOL "https://github.com/wagoodman/dive/releases/download/v${DIVE_VERSION}/dive_${DIVE_VERSION}_linux_amd64.rpm"
 rpm -i dive_${DIVE_VERSION}_linux_amd64.rpm
 ```
 


### PR DESCRIPTION
Hi,

Wrapping the endpoints in `"` characters prevents zsh from interpreting them when copy-pasting the command.

The `-f` option ensures that an invalid `.deb` or `.rpm` file is not created if the curl command fails to download the actual file.