### PR TITLE
README.md: Add x-cmd method to install dive

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ On non-NixOS (Linux, Mac)
 nix-env -iA nixpkgs.dive
 ```
 
+**X-CMD**
+
+[x-cmd](https://www.x-cmd.com/) is a **toolbox for Posix Shell**, offering a lightweight package manager built using shell and awk.
+```sh
+x env use dive
+```
+
 **Docker**
 ```bash
 docker pull wagoodman/dive


### PR DESCRIPTION
- Hi, we have implemented a lightweight [package manager using shell and awk](https://www.x-cmd.com/pkg/). It helps you download dive release packages from the internet and extract them into a unified directory for management, without requiring root permissions.

- **I mean, can the installation method provided by x-cmd be added to the dive README?**[The installation method for the x command](https://www.x-cmd.com/start/)
  ```sh
  x env use dive 
  ```