### PR TITLE
Added ppc64le support

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -17,6 +17,7 @@ builds:
     goarch:
       - amd64
       - arm64
+      - ppc64le
     ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.buildTime={{.Date}}`.
 
 brews:


### PR DESCRIPTION
Hello Team,

I've updated the specified files to enable the release of ppc64le binaries and docker image for gosec.
- Updated **.goreleaser.yml** to support Linux on IBM Power ( ppc64le )

Signed-off-by: Pooja Shah [Pooja.Shah4@ibm.com](mailto:Pooja.Shah4@ibm.com)