### PR TITLE
Fix: update readme instructions on building with go tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,10 +146,11 @@ Or download the latest Darwin build from the [releases page](https://github.com/
 Download the [latest release](https://github.com/wagoodman/dive/releases/latest).
 
 **Go tools**
+
 Requires Go version 1.10 or higher.
 
 ```bash
-go get github.com/wagoodman/dive
+go install github.com/wagoodman/dive@latest
 ```
 *Note*: installing in this way you will not see a proper version when running `dive -v`.
 


### PR DESCRIPTION
`go get github.com/wagoodman/dive` no longer works.

This is the fix.