### PR TITLE
efficiency: track which layers a file was in

### DIFF
--- a/dive/filetree/efficiency.go
+++ b/dive/filetree/efficiency.go
@@ -12,6 +12,15 @@ type EfficiencyData struct {
 	Nodes             []*FileNode
 	CumulativeSize    int64
 	minDiscoveredSize int64
+	Layers            []int
+}
+
+func (ed EfficiencyData) FirstLayer() int {
+	return ed.Layers[0]
+}
+
+func (ed EfficiencyData) SubsequentLayers() []int {
+	return ed.Layers[1:]
 }
 
 // EfficiencySlice represents an ordered set of EfficiencyData data structures.
@@ -42,14 +51,21 @@ func Efficiency(trees []*FileTree) (float64, EfficiencySlice) {
 
 	visitor := func(node *FileNode) error {
 		path := node.Path()
+		first := false
 		if _, ok := efficiencyMap[path]; !ok {
 			efficiencyMap[path] = &EfficiencyData{
 				Path:              path,
 				Nodes:             make([]*FileNode, 0),
 				minDiscoveredSize: -1,
+				Layers:            []int{currentTree},
 			}
+			first = true
 		}
 		data := efficiencyMap[path]
+
+		if !first {
+			data.Layers = append(data.Layers, currentTree)
+		}
 
 		// this node may have had children that were deleted, however, we won't explicitly list out every child, only
 		// the top-most parent with the cumulative size. These operations will need to be done on the full (stacked)

--- a/dive/filetree/efficiency_test.go
+++ b/dive/filetree/efficiency_test.go
@@ -1,6 +1,7 @@
 package filetree
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -32,7 +33,11 @@ func TestEfficency(t *testing.T) {
 
 	var expectedScore = 0.75
 	var expectedMatches = EfficiencySlice{
-		&EfficiencyData{Path: "/etc/nginx/nginx.conf", CumulativeSize: 7000},
+		&EfficiencyData{
+			Path:           "/etc/nginx/nginx.conf",
+			CumulativeSize: 7000,
+			Layers:         []int{0, 1},
+		},
 	}
 	actualScore, actualMatches := Efficiency(trees)
 
@@ -49,6 +54,19 @@ func TestEfficency(t *testing.T) {
 
 	if expectedMatches[0].Path != actualMatches[0].Path {
 		t.Errorf("Expected path of %s but go %s", expectedMatches[0].Path, actualMatches[0].Path)
+	}
+
+	if !reflect.DeepEqual(expectedMatches[0].Layers, actualMatches[0].Layers) {
+		t.Errorf("Expected layers of %v but got %v", expectedMatches[0].Layers, actualMatches[0].Layers)
+	}
+
+	if actualMatches[0].FirstLayer() != 0 {
+		t.Errorf("expected first layer 0 but got %v", actualMatches[0].FirstLayer())
+	}
+
+	expectedSubsequent := []int{1}
+	if !reflect.DeepEqual(actualMatches[0].SubsequentLayers(), expectedSubsequent) {
+		t.Errorf("expected subsequent layers %v but got %v", expectedSubsequent, actualMatches[0].SubsequentLayers())
 	}
 
 	if expectedMatches[0].CumulativeSize != actualMatches[0].CumulativeSize {


### PR DESCRIPTION
we are building some tooling to track *which* layers files were in, so we can automatically print out which commands or base layers need to be changed or updated. we could write an additional visitor, but the existing efficiency visitor almost does this, so let's just track it here.