### PR TITLE
fix: Login to GHCR as owner not actor

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -111,7 +111,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build & publish release artifacts


### PR DESCRIPTION
The official docs do document the login step with `username: ${{ github.actor }}`, which will be the user that triggered a workflow event. For consistency, prefer `${{ github.repository_owner }}` instead, which will be specific to the repo that the workflow is running at.