### PR TITLE
Update docker image release definitions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -83,9 +83,6 @@ jobs:
       contents: write
       # for pushing container images
       packages: write
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -93,12 +90,6 @@ jobs:
 
       - name: Bootstrap environment
         uses: ./.github/actions/bootstrap
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
 
       - name: Tag release
         run: |
@@ -110,7 +101,7 @@ jobs:
       - name: Login to container registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
+          registry: docker.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -59,7 +59,7 @@ dockers:
     use: buildx
     goarch: amd64
     image_templates:
-      - docker.io/wagoodman/dive:{{.Version}}-amd64
+      - docker.io/wagoodman/dive:v{{.Version}}-amd64
     build_flag_templates:
       - "--build-arg=DOCKER_CLI_VERSION={{.Env.DOCKER_CLI_VERSION}}"
       - "--platform=linux/amd64"
@@ -81,7 +81,7 @@ dockers:
     use: buildx
     goarch: arm64
     image_templates:
-      - docker.io/wagoodman/dive:{{.Version}}-arm64
+      - docker.io/wagoodman/dive:v{{.Version}}-arm64
     build_flag_templates:
       - "--build-arg=DOCKER_CLI_VERSION={{.Env.DOCKER_CLI_VERSION}}"
       - "--platform=linux/arm64/v8"
@@ -99,41 +99,41 @@ dockers:
   - id: ghcr-amd64
     <<: *dockerhub_amd64
     image_templates:
-      - ghcr.io/wagoodman/dive:{{.Version}}-amd64
+      - ghcr.io/wagoodman/dive:v{{.Version}}-amd64
 
   # ghcr.io arm64
   - id: ghcr-arm64
     <<: *dockerhub_arm64
     image_templates:
-      - ghcr.io/wagoodman/dive:{{.Version}}-arm64
+      - ghcr.io/wagoodman/dive:v{{.Version}}-arm64
 
 docker_manifests:
   # docker.io manifests
   - name_template: docker.io/wagoodman/dive:latest
     image_templates: &dockerhub_images
-      - docker.io/wagoodman/dive:{{.Version}}-amd64
-      - docker.io/wagoodman/dive:{{.Version}}-arm64
+      - docker.io/wagoodman/dive:v{{.Version}}-amd64
+      - docker.io/wagoodman/dive:v{{.Version}}-arm64
 
-  - name_template: docker.io/wagoodman/dive:{{.Major}}
+  - name_template: docker.io/wagoodman/dive:v{{.Major}}
     image_templates: *dockerhub_images
 
-  - name_template: docker.io/wagoodman/dive:{{.Major}}.{{.Minor}}
+  - name_template: docker.io/wagoodman/dive:v{{.Major}}.{{.Minor}}
     image_templates: *dockerhub_images
 
-  - name_template: docker.io/wagoodman/dive:{{.Version}}
+  - name_template: docker.io/wagoodman/dive:v{{.Version}}
     image_templates: *dockerhub_images
 
   # ghcr.io manifests
   - name_template: ghcr.io/wagoodman/dive:latest
     image_templates: &ghcr_images
-      - ghcr.io/wagoodman/dive:{{.Version}}-amd64
-      - ghcr.io/wagoodman/dive:{{.Version}}-arm64
+      - ghcr.io/wagoodman/dive:v{{.Version}}-amd64
+      - ghcr.io/wagoodman/dive:v{{.Version}}-arm64
 
-  - name_template: ghcr.io/wagoodman/dive:{{.Major}}
+  - name_template: ghcr.io/wagoodman/dive:v{{.Major}}
     image_templates: *ghcr_images
 
-  - name_template: ghcr.io/wagoodman/dive:{{.Major}}.{{.Minor}}
+  - name_template: ghcr.io/wagoodman/dive:v{{.Major}}.{{.Minor}}
     image_templates: *ghcr_images
 
-  - name_template: ghcr.io/wagoodman/dive:{{.Version}}
+  - name_template: ghcr.io/wagoodman/dive:v{{.Version}}
     image_templates: *ghcr_images

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,11 @@ release:
   # If set to true, will not auto-publish the release. This is done to allow us to review the changelog before publishing.
   draft: false
 
+env:
+  # required to support multi architecture docker builds
+  - DOCKER_CLI_EXPERIMENTAL=enabled
+  - CGO_ENABLED=0
+
 builds:
   - binary: dive
     env:
@@ -20,15 +25,15 @@ builds:
       - amd64
       - arm64
       - ppc64le
-    ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.buildTime={{.Date}}`.
+    ldflags: -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.buildTime={{.Date}}
 
 brews:
   - repository:
       owner: wagoodman
       name: homebrew-dive
       token: "{{.Env.TAP_GITHUB_TOKEN}}"
-    homepage: "https://github.com/wagoodman/dive/"
-    description: "A tool for exploring layers in a docker image"
+    homepage: &project_url "https://github.com/wagoodman/dive/"
+    description: &description "A tool for exploring layers in a docker image"
 
 archives:
   - format: tar.gz
@@ -39,51 +44,96 @@ archives:
 nfpms:
   - license: MIT
     maintainer: Alex Goodman
-    homepage: https://github.com/wagoodman/dive/
-    description: "A tool for exploring layers in a docker image"
+    homepage: *project_url
+    description: *description
     formats:
       - rpm
       - deb
 
 dockers:
-  - id: docker-amd64
+  # docker.io amd64
+  - &dockerhub_amd64
+    id: docker-amd64
     ids:
       - dive
     use: buildx
     goarch: amd64
     image_templates:
-      - '{{ envOrDefault "REGISTRY" "docker.io" }}/wagoodman/dive:latest-amd64'
-      - '{{ envOrDefault "REGISTRY" "docker.io" }}/wagoodman/dive:{{ .Version }}-amd64'
+      - docker.io/wagoodman/dive:{{.Version}}-amd64
     build_flag_templates:
       - "--build-arg=DOCKER_CLI_VERSION={{.Env.DOCKER_CLI_VERSION}}"
+      - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.description=A tool for exploring layers in a docker image"
+      - "--label=org.opencontainers.image.url={{.GitURL}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--platform=linux/amd64"
-  - id: docker-arm64
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+      - "--label=org.opencontainers.image.authors=Alex Goodman <@wagoodman>"
+
+  # docker.io arm64
+  - &dockerhub_arm64
+    id: docker-arm64
     ids:
       - dive
     use: buildx
     goarch: arm64
     image_templates:
-      - '{{ envOrDefault "REGISTRY" "docker.io" }}/wagoodman/dive:latest-arm64'
-      - '{{ envOrDefault "REGISTRY" "docker.io" }}/wagoodman/dive:{{ .Version }}-arm64'
+      - docker.io/wagoodman/dive:{{.Version}}-arm64
     build_flag_templates:
       - "--build-arg=DOCKER_CLI_VERSION={{.Env.DOCKER_CLI_VERSION}}"
+      - "--platform=linux/arm64/v8"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
-      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
-      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.description=A tool for exploring layers in a docker image"
+      - "--label=org.opencontainers.image.url={{.GitURL}}"
       - "--label=org.opencontainers.image.source={{.GitURL}}"
-      - "--platform=linux/arm64/v8"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.licenses=MIT"
+      - "--label=org.opencontainers.image.authors=Alex Goodman <@wagoodman>"
+
+  # ghcr.io amd64
+  - id: ghcr-amd64
+    <<: *dockerhub_amd64
+    image_templates:
+      - ghcr.io/wagoodman/dive:{{.Version}}-amd64
+
+  # ghcr.io arm64
+  - id: ghcr-arm64
+    <<: *dockerhub_arm64
+    image_templates:
+      - ghcr.io/wagoodman/dive:{{.Version}}-arm64
+
 docker_manifests:
-  - name_template: '{{ envOrDefault "REGISTRY" "docker.io" }}/wagoodman/dive:latest'
-    image_templates:
-      - '{{ envOrDefault "REGISTRY" "docker.io" }}/wagoodman/dive:latest-amd64'
-      - '{{ envOrDefault "REGISTRY" "docker.io" }}/wagoodman/dive:latest-arm64'
-  - name_template: '{{ envOrDefault "REGISTRY" "docker.io" }}/wagoodman/dive:{{ .Version }}'
-    image_templates:
-      - '{{ envOrDefault "REGISTRY" "docker.io" }}/wagoodman/dive:{{ .Version }}-amd64'
-      - '{{ envOrDefault "REGISTRY" "docker.io" }}/wagoodman/dive:{{ .Version }}-arm64'
+  # docker.io manifests
+  - name_template: docker.io/wagoodman/dive:latest
+    image_templates: &dockerhub_images
+      - docker.io/wagoodman/dive:{{.Version}}-amd64
+      - docker.io/wagoodman/dive:{{.Version}}-arm64
+
+  - name_template: docker.io/wagoodman/dive:{{.Major}}
+    image_templates: *dockerhub_images
+
+  - name_template: docker.io/wagoodman/dive:{{.Major}}.{{.Minor}}
+    image_templates: *dockerhub_images
+
+  - name_template: docker.io/wagoodman/dive:{{.Version}}
+    image_templates: *dockerhub_images
+
+  # ghcr.io manifests
+  - name_template: ghcr.io/wagoodman/dive:latest
+    image_templates: &ghcr_images
+      - ghcr.io/wagoodman/dive:{{.Version}}-amd64
+      - ghcr.io/wagoodman/dive:{{.Version}}-arm64
+
+  - name_template: ghcr.io/wagoodman/dive:{{.Major}}
+    image_templates: *ghcr_images
+
+  - name_template: ghcr.io/wagoodman/dive:{{.Major}}.{{.Minor}}
+    image_templates: *ghcr_images
+
+  - name_template: ghcr.io/wagoodman/dive:{{.Version}}
+    image_templates: *ghcr_images

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 BIN = dive
 TEMP_DIR = ./.tmp
 PWD := ${CURDIR}
-REGISTRY ?= docker.io
 SHELL = /bin/bash -o pipefail
 TEST_IMAGE = busybox:latest
 
@@ -213,7 +212,7 @@ ci-test-docker-image:
 		--rm \
 		-t \
 		-v /var/run/docker.sock:/var/run/docker.sock \
-		'${REGISTRY}/wagoodman/dive:latest-amd64' \
+		'docker.io/wagoodman/dive:latest-amd64' \
 			'${TEST_IMAGE}' \
 			--ci
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ nix-env -iA nixpkgs.dive
 **Docker**
 ```bash
 docker pull docker.io/wagoodman/dive
+# or alternatively
+docker pull ghcr.io/wagoodman/dive
 ```
 
 When running you'll need to include the Docker socket file:


### PR DESCRIPTION
The following changes were made to the release pipeline:
- removed the need to install qemu and buildx as the same functionality is now built into docker natively
- removed REGISTRY references to swap out where the image is being pushed to
- pushes to both `ghcr.io` and `docker.io` registries
- tags built include `vMAJOR`, `vMAJOR.MINOR`, and `vMAJOR.MINOR.PATCH` tags
- update README to include reference to ghcr.io image 

Closes #573