### PR TITLE
Fix layer selection to select only one layer at a time

### DIFF
--- a/runtime/ui/format/format.go
+++ b/runtime/ui/format/format.go
@@ -46,17 +46,25 @@ var (
 	StatusControlNormal   func(...interface{}) string
 	CompareTop            func(...interface{}) string
 	CompareBottom         func(...interface{}) string
+	reset                 = color.New(color.Reset).Sprint("")
 )
 
 func init() {
-	Selected = color.New(color.ReverseVideo, color.Bold).SprintFunc()
-	Header = color.New(color.Bold).SprintFunc()
-	StatusSelected = color.New(color.BgMagenta, color.FgWhite).SprintFunc()
-	StatusNormal = color.New(color.ReverseVideo).SprintFunc()
-	StatusControlSelected = color.New(color.BgMagenta, color.FgWhite, color.Bold).SprintFunc()
-	StatusControlNormal = color.New(color.ReverseVideo, color.Bold).SprintFunc()
-	CompareTop = color.New(color.BgMagenta).SprintFunc()
-	CompareBottom = color.New(color.BgGreen).SprintFunc()
+	wrapper := func(fn func(a ...any) string) func(a ...any) string {
+		return func(a ...any) string {
+			// for some reason not all color formatter functions are not applying RESET, we'll add it manually for now
+			return fn(a...) + reset
+		}
+	}
+
+	Selected = wrapper(color.New(color.ReverseVideo, color.Bold).SprintFunc())
+	Header = wrapper(color.New(color.Bold).SprintFunc())
+	StatusSelected = wrapper(color.New(color.BgMagenta, color.FgWhite).SprintFunc())
+	StatusNormal = wrapper(color.New(color.ReverseVideo).SprintFunc())
+	StatusControlSelected = wrapper(color.New(color.BgMagenta, color.FgWhite, color.Bold).SprintFunc())
+	StatusControlNormal = wrapper(color.New(color.ReverseVideo, color.Bold).SprintFunc())
+	CompareTop = wrapper(color.New(color.BgMagenta).SprintFunc())
+	CompareBottom = wrapper(color.New(color.BgGreen).SprintFunc())
 }
 
 func RenderNoHeader(width int, selected bool) string {

--- a/runtime/ui/view/layer.go
+++ b/runtime/ui/view/layer.go
@@ -2,7 +2,6 @@ package view
 
 import (
 	"fmt"
-
 	"github.com/awesome-gocui/gocui"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"


### PR DESCRIPTION
It looks like some of the time I'm seeing the layers view become a little overzealous when it comes to selecting a single layer:

<img width="653" alt="Screenshot 2025-03-29 at 10 18 54 AM" src="https://github.com/user-attachments/assets/6dc9479c-f360-496e-9733-0e27c5e29d28" />

This forces any formatting function to have a ansi reset at the end.