### PR TITLE
Fix mismatches between layers and their contents for OCI Images

### DIFF
--- a/dive/image/docker/manifest.go
+++ b/dive/image/docker/manifest.go
@@ -3,6 +3,10 @@ package docker
 import (
 	"encoding/json"
 	"fmt"
+	"path/filepath"
+
+	digest "github.com/opencontainers/go-digest"
+	oci "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type manifest struct {
@@ -18,4 +22,41 @@ func newManifest(manifestBytes []byte) manifest {
 		panic(fmt.Errorf("failed to unmarshal manifest: %w", err))
 	}
 	return manifest[0]
+}
+
+func newOCIManifest(manifestBytes []byte) oci.Manifest {
+	ociManifest := oci.Manifest{}
+	err := json.Unmarshal(manifestBytes, &ociManifest)
+	if err != nil {
+		panic(fmt.Errorf("failed to unmarshal manifest: %w", err))
+	}
+	if ociManifest.MediaType != oci.MediaTypeImageManifest {
+		panic(fmt.Errorf("mediaType mismatch: expected '%s', found '%s'", oci.MediaTypeImageManifest, ociManifest.MediaType))
+	}
+	return ociManifest
+}
+
+func extractManifest(indexBytes []byte) oci.Descriptor {
+	ociIndex := oci.Index{}
+	err := json.Unmarshal(indexBytes, &ociIndex)
+	if err != nil {
+		panic(fmt.Errorf("failed to unmarshal index: %w", err))
+	}
+	manifests := ociIndex.Manifests
+	if len(manifests) == 0 {
+		panic(fmt.Errorf("No manifest found"))
+	}
+	return manifests[0]
+}
+
+func digestPath(d digest.Digest) string {
+	return filepath.Join(oci.ImageBlobsDir, d.Algorithm().String(), d.Encoded())
+}
+
+func layerPaths(ociManifest oci.Manifest) []string {
+	var layerPaths []string
+	for _, path := range ociManifest.Layers {
+		layerPaths = append(layerPaths, digestPath(path.Digest))
+	}
+	return layerPaths
 }

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/lunixbochs/vtclean v1.0.0
 	github.com/muesli/termenv v0.16.0
+	github.com/opencontainers/go-digest v1.0.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/phayes/permbits v0.0.0-20190612203442-39d7c581d2ee
 	github.com/scylladb/go-set v1.0.2
 	github.com/spf13/afero v1.14.0
@@ -79,8 +81,6 @@ require (
 	github.com/moby/docker-image-spec v1.3.1 // indirect
 	github.com/moby/term v0.5.0 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.0.2 // indirect
 	github.com/pborman/indent v1.2.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -160,8 +160,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
-github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/image-spec v1.1.1 h1:y0fUlFfIZhPF1W537XOLg0/fcx6zcHCJwooC2xJA040=
+github.com/opencontainers/image-spec v1.1.1/go.mod h1:qpqAh3Dmcf36wStyyWU+kCeDgrGnAve2nCC8+7h8Q0M=
 github.com/pborman/indent v1.2.1 h1:lFiviAbISHv3Rf0jcuh489bi06hj98JsVMtIDZQb9yM=
 github.com/pborman/indent v1.2.1/go.mod h1:FitS+t35kIYtB5xWTZAPhnmrxcciEEOdbyrrpz5K6Vw=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=


### PR DESCRIPTION
Analyzing an image that meets the OCI Image Layout Specification results in confusing behavior where the layer contents shown may not correspond to the selected layer.

This specifically happens when the image contains `index.json` and not `manifest.json` (which it should, according to https://github.com/opencontainers/image-spec/blob/main/image-layout.md#content), thus triggering the manifest detection logic added in #570 (via https://github.com/joschi/dive/pull/53).