### PR TITLE
Simplify dive installation via homebrew core

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,7 @@ pacman -S dive
 If you use [Homebrew](https://brew.sh):
 
 ```bash
-brew tap wagoodman/dive
-brew install wagoodman/dive/dive
+brew install dive
 ```
 
 If you use [MacPorts](https://www.macports.org):


### PR DESCRIPTION
With the merge of #213, the package was added to Homebrew core, and the README was updated accordingly to remove the manual tap.

However, with the merge of #570, the README reverted to recommending the tap instead of the core package. I couldn't find any reason for this change, and I personally try to avoid unnecessary taps whenever possible.