### PR TITLE
Fix segfault during file extraction (#620)

### DIFF
--- a/cmd/dive/cli/internal/ui/v1/view/filetree.go
+++ b/cmd/dive/cli/internal/ui/v1/view/filetree.go
@@ -2,6 +2,8 @@ package view
 
 import (
 	"fmt"
+	"regexp"
+
 	"github.com/anchore/go-logger"
 	"github.com/wagoodman/dive/cmd/dive/cli/internal/ui/v1"
 	"github.com/wagoodman/dive/cmd/dive/cli/internal/ui/v1/format"
@@ -9,7 +11,6 @@ import (
 	"github.com/wagoodman/dive/cmd/dive/cli/internal/ui/v1/viewmodel"
 	"github.com/wagoodman/dive/internal/log"
 	"github.com/wagoodman/dive/internal/utils"
-	"regexp"
 
 	"github.com/awesome-gocui/gocui"
 	"github.com/wagoodman/dive/dive/filetree"
@@ -99,7 +100,7 @@ func (v *FileTree) Setup(view, header *gocui.View) error {
 	v.header.Wrap = false
 	v.header.Frame = false
 
-	var infos = []key.BindingInfo{
+	infos := []key.BindingInfo{
 		{
 			Config:   v.kb.Filetree.ToggleCollapseDir,
 			OnAction: v.toggleCollapse,
@@ -322,6 +323,9 @@ func (v *FileTree) toggleSortOrder() error {
 
 func (v *FileTree) extractFile() error {
 	node := v.vm.CurrentNode(v.filterRegex)
+	if node == nil {
+		return fmt.Errorf("no file selected for extraction")
+	}
 	for _, listener := range v.extractListeners {
 		err := listener(node.Path())
 		if err != nil {

--- a/cmd/dive/cli/internal/ui/v1/viewmodel/filetree.go
+++ b/cmd/dive/cli/internal/ui/v1/viewmodel/filetree.go
@@ -3,11 +3,12 @@ package viewmodel
 import (
 	"bytes"
 	"fmt"
+	"regexp"
+	"strings"
+
 	"github.com/wagoodman/dive/cmd/dive/cli/internal/ui/v1"
 	"github.com/wagoodman/dive/cmd/dive/cli/internal/ui/v1/format"
 	"github.com/wagoodman/dive/internal/log"
-	"regexp"
-	"strings"
 
 	"github.com/lunixbochs/vtclean"
 	"github.com/wagoodman/dive/dive/filetree"
@@ -176,6 +177,9 @@ func (vm *FileTreeViewModel) CursorLeft(filterRegex *regexp.Regexp) error {
 	currentNode := vm.getAbsPositionNode(filterRegex)
 
 	if currentNode == nil {
+		return nil
+	}
+	if currentNode.Parent == nil {
 		return nil
 	}
 	parentPath := currentNode.Parent.Path()
@@ -424,7 +428,6 @@ func (vm *FileTreeViewModel) Update(filterRegex *regexp.Regexp, width, height in
 		}
 		return nil
 	}, nil)
-
 	if err != nil {
 		return fmt.Errorf("unable to propagate vm model tree: %w", err)
 	}
@@ -440,7 +443,6 @@ func (vm *FileTreeViewModel) Update(filterRegex *regexp.Regexp, width, height in
 		}
 		return nil
 	}, nil)
-
 	if err != nil {
 		return fmt.Errorf("unable to propagate vm view tree: %w", err)
 	}

--- a/cmd/dive/cli/internal/ui/v1/viewmodel/filetree_test.go
+++ b/cmd/dive/cli/internal/ui/v1/viewmodel/filetree_test.go
@@ -2,17 +2,18 @@ package viewmodel
 
 import (
 	"flag"
-	"github.com/google/go-cmp/cmp"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/wagoodman/dive/cmd/dive/cli/internal/ui/v1"
-	"go.uber.org/atomic"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/wagoodman/dive/cmd/dive/cli/internal/ui/v1"
+	"go.uber.org/atomic"
 
 	"github.com/wagoodman/dive/dive/filetree"
 	"github.com/wagoodman/dive/dive/image/docker"
@@ -56,8 +57,7 @@ func helperCaptureBytes(t *testing.T, data []byte) {
 	}
 
 	path := testCaseDataFilePath(t.Name())
-	err := os.WriteFile(path, data, 0644)
-
+	err := os.WriteFile(path, data, 0o644)
 	if err != nil {
 		t.Fatalf("unable to save test data ('%s'): %+v", t.Name(), err)
 	}
@@ -419,4 +419,34 @@ func repoRoot(t testing.TB) string {
 	val = strings.TrimSpace(string(out))
 	repoRootCache.Store(val)
 	return val
+}
+
+// TestCursorLeftWithNilParent tests that CursorLeft handles nil parent gracefully
+func TestCursorLeftWithNilParent(t *testing.T) {
+	// Use the standard test initialization
+	vm := initializeTestViewModel(t)
+
+	// Set tree index to 0 (root node)
+	vm.TreeIndex = 0
+
+	// Call CursorLeft - should not panic even though root has no parent
+	err := vm.CursorLeft(nil)
+
+	// Should return without error and not panic
+	require.NoError(t, err)
+}
+
+// TestGetAbsPositionNodeReturnsNil tests that getAbsPositionNode can return nil
+func TestGetAbsPositionNodeReturnsNil(t *testing.T) {
+	// Use the standard test initialization
+	vm := initializeTestViewModel(t)
+
+	// Set tree index to a position that doesn't exist
+	vm.TreeIndex = 100000
+
+	// Call getAbsPositionNode - should return nil
+	node := vm.getAbsPositionNode(nil)
+
+	// Should return nil without panic
+	require.Nil(t, node)
 }

--- a/dive/filetree/file_node.go
+++ b/dive/filetree/file_node.go
@@ -3,8 +3,9 @@ package filetree
 import (
 	"archive/tar"
 	"fmt"
-	"github.com/wagoodman/dive/internal/log"
 	"strings"
+
+	"github.com/wagoodman/dive/internal/log"
 
 	"github.com/dustin/go-humanize"
 	"github.com/fatih/color"
@@ -191,7 +192,6 @@ func (node *FileNode) GetSize() int64 {
 		sizeBytes = node.Data.FileInfo.Size
 	} else {
 		sizer := func(curNode *FileNode) error {
-
 			if curNode.Data.DiffType != Removed || node.Data.DiffType == Removed {
 				sizeBytes += curNode.Data.FileInfo.Size
 			}
@@ -273,6 +273,9 @@ func (node *FileNode) IsLeaf() bool {
 
 // Path returns a slash-delimited string from the root of the greater tree to the current node (e.g. /a/path/to/here)
 func (node *FileNode) Path() string {
+	if node == nil {
+		return ""
+	}
 	if node.path == "" {
 		var path []string
 		curNode := node

--- a/dive/filetree/file_node_test.go
+++ b/dive/filetree/file_node_test.go
@@ -43,7 +43,6 @@ func TestAddChild(t *testing.T) {
 	if expectedFC.Path != actualFC.Path {
 		t.Errorf("Expected 'ones' payload to be %+v got %+v.", expectedFC, actualFC)
 	}
-
 }
 
 func TestRemoveChild(t *testing.T) {
@@ -79,7 +78,6 @@ func TestRemoveChild(t *testing.T) {
 	if tree.Root.Children["nil"] != nil {
 		t.Errorf("Expected 'nil' node to be deleted.")
 	}
-
 }
 
 func TestPath(t *testing.T) {
@@ -130,6 +128,7 @@ func TestDiffTypeFromAddedChildren(t *testing.T) {
 		t.Errorf("Expected Modified but got %v", tree.Root.Children["usr"].Data.DiffType)
 	}
 }
+
 func TestDiffTypeFromRemovedChildren(t *testing.T) {
 	tree := NewFileTree()
 	_, _, _ = tree.AddPath("/usr", *BlankFileChangeInfo("/usr"))
@@ -148,7 +147,6 @@ func TestDiffTypeFromRemovedChildren(t *testing.T) {
 	if tree.Root.Children["usr"].Data.DiffType != Modified {
 		t.Errorf("Expected Modified but got %v", tree.Root.Children["usr"].Data.DiffType)
 	}
-
 }
 
 func TestDirSize(t *testing.T) {
@@ -164,5 +162,44 @@ func TestDirSize(t *testing.T) {
 	expected, actual := "----------         0:0      600 B ", node.MetadataString()
 	if expected != actual {
 		t.Errorf("Expected metadata '%s' got '%s'", expected, actual)
+	}
+}
+
+// TestNilNodePath tests that calling Path() on a nil node returns empty string without panic
+func TestNilNodePath(t *testing.T) {
+	var node *FileNode
+
+	// This should not panic and should return empty string
+	result := node.Path()
+	expected := ""
+
+	if result != expected {
+		t.Errorf("Expected Path() on nil node to return '%s', got '%s'", expected, result)
+	}
+}
+
+// TestNilNodeString tests that calling String() on a nil node returns empty string without panic
+func TestNilNodeString(t *testing.T) {
+	var node *FileNode
+
+	// This should not panic and should return empty string
+	result := node.String()
+	expected := ""
+
+	if result != expected {
+		t.Errorf("Expected String() on nil node to return '%s', got '%s'", expected, result)
+	}
+}
+
+// TestNilNodeMetadataString tests that calling MetadataString() on a nil node returns empty string without panic
+func TestNilNodeMetadataString(t *testing.T) {
+	var node *FileNode
+
+	// This should not panic and should return empty string
+	result := node.MetadataString()
+	expected := ""
+
+	if result != expected {
+		t.Errorf("Expected MetadataString() on nil node to return '%s', got '%s'", expected, result)
 	}
 }


### PR DESCRIPTION
## Summary
Fixes segfault that occurs during file extraction when no valid file is selected.

## Root Cause
The segfault occurred in the `extractFile()` method when:
1. `vm.CurrentNode()` returned `nil` (no valid file selected)
2. `extractFile()` called `node.Path()` on the nil node
3. `Path()` method accessed `node.path` on a nil pointer causing segfault

## Changes Made

### 1. Primary Fix - extractFile() Method
- **File**: `cmd/dive/cli/internal/ui/v1/view/filetree.go`
- **Fix**: Added nil check before calling `node.Path()`
- **Impact**: Prevents the exact segfault described in the issue

### 2. Defensive Fix - Path() Method  
- **File**: `dive/filetree/file_node.go`
- **Fix**: Added nil receiver check at the beginning of the method
- **Impact**: Provides additional safety layer for all Path() calls

### 3. Safety Fix - CursorLeft() Method
- **File**: `cmd/dive/cli/internal/ui/v1/viewmodel/filetree.go`
- **Fix**: Added check for nil parent before accessing `currentNode.Parent.Path()`
- **Impact**: Prevents potential crashes when navigating to parent nodes

## Test Coverage
Extended test coverage with 5 new test cases:
- `TestNilNodePath`: Tests Path() method with nil receiver
- `TestNilNodeString`: Tests String() method with nil receiver  
- `TestNilNodeMetadataString`: Tests MetadataString() method with nil receiver
- `TestCursorLeftWithNilParent`: Tests CursorLeft() with nil parent
- `TestGetAbsPositionNodeReturnsNil`: Tests getAbsPositionNode() returning nil

## Solution Approach
The fix follows a defense-in-depth approach:
- **Immediate protection**: Nil check in extractFile() prevents the crash
- **Defensive programming**: Nil check in Path() method provides additional safety
- **Navigation safety**: Parent nil check in CursorLeft() prevents related issues

## Testing
- ✅ All existing tests continue to pass
- ✅ All new tests pass
- ✅ Project builds successfully
- ✅ Manual testing confirms no segfaults occur

Fixes #620