### PR TITLE
refactor tests by using t.Chdir

### DIFF
--- a/cmd/dive/cli/cli_ci_test.go
+++ b/cmd/dive/cli/cli_ci_test.go
@@ -11,7 +11,7 @@ func Test_CI_DefaultCIConfig(t *testing.T) {
 	t.Setenv("DIVE_CONFIG", "-")
 
 	rootCmd := getTestCommand(t, repoPath(t, ".data/test-docker-image.tar")+" -vv")
-	cd(t, "testdata/default-ci-config")
+	t.Chdir("testdata/default-ci-config")
 	combined := Capture().WithStdout().WithStderr().Run(t, func() {
 		// failing gate should result in a non-zero exit code
 		require.Error(t, rootCmd.Execute())

--- a/cmd/dive/cli/cli_load_test.go
+++ b/cmd/dive/cli/cli_load_test.go
@@ -93,13 +93,3 @@ func Test_FetchFailure(t *testing.T) {
 		snaps.MatchSnapshot(t, combined)
 	})
 }
-
-func cd(t testing.TB, to string) {
-	t.Helper()
-	from, err := os.Getwd()
-	require.NoError(t, err)
-	require.NoError(t, os.Chdir(to))
-	t.Cleanup(func() {
-		require.NoError(t, os.Chdir(from))
-	})
-}


### PR DESCRIPTION
This PR simplifies tests with [`T.Chdir`](https://pkg.go.dev/testing#T.Chdir).