### PR TITLE
fix: Commented out highestUserWastedPercent is not skipped, but set to 0.1

### DIFF
--- a/cmd/dive/cli/internal/options/ci_rules.go
+++ b/cmd/dive/cli/internal/options/ci_rules.go
@@ -23,7 +23,7 @@ func DefaultCIRules() CIRules {
 	return CIRules{
 		LowestEfficiencyThresholdString: "0.9",
 		HighestWastedBytesString:        "disabled",
-		HighestUserWastedPercentString:  "0.1",
+		HighestUserWastedPercentString:  "disabled",
 	}
 }
 

--- a/cmd/dive/cli/testdata/image-multi-layer-dockerfile/dive-fail.yaml
+++ b/cmd/dive/cli/testdata/image-multi-layer-dockerfile/dive-fail.yaml
@@ -1,3 +1,4 @@
 ci: true
 rules:
   lowest-efficiency-threshold: '0.9'
+  highest-user-wasted-percent: '0.1'


### PR DESCRIPTION
Fixes #606

## Summary
When `highestUserWastedPercent` is commented out in the YAML config, it should be disabled (skipped), not default to 0.1.

## Changes
- Change default `HighestUserWastedPercentString` from `"0.1"` to `"disabled"` in `DefaultCIRules()`
- Add explicit `highest-user-wasted-percent: '0.1'` to `dive-fail.yaml` testdata to maintain test behavior

## Root Cause
The default value was `"0.1"` which meant that when a user commented out the `highest-user-wasted-percent` config value, the rule would still apply with a 0.1 (10%) threshold instead of being disabled.