### PR TITLE
Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to dive! This document covers how to
 
 ## Prerequisites
 
-- [Go](https://go.dev/dl/) 1.21 or later
+- [Go](https://go.dev/dl/) 1.24 or later
 - [Docker](https://docs.docker.com/get-docker/) (required for integration/CLI tests)
 - `make` or `task` (see [Bootstrapping](#bootstrapping) below)
 
@@ -40,7 +40,7 @@ This produces a local snapshot binary via [goreleaser](https://goreleaser.com). 
 For a quick dev build without goreleaser:
 
 ```bash
-go build -o dive .
+go build -o dive ./cmd/dive
 ```
 
 ## Running the tests
@@ -100,4 +100,4 @@ runtime/      TUI, CI mode, export, and test-CLI
 
 ## License
 
-By contributing you agree that your changes will be licensed under the [Apache 2.0 License](LICENSE).
+By contributing you agree that your changes will be licensed under the [MIT License](LICENSE).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,8 +11,10 @@ Thank you for your interest in contributing to dive! This document covers how to
 ## Getting the source
 
 ```bash
-git clone https://github.com/wagoodman/dive.git
+# Fork the repo on GitHub first, then:
+git clone https://github.com/<your-username>/dive.git
 cd dive
+git remote add upstream https://github.com/wagoodman/dive.git
 ```
 
 ## Bootstrapping
@@ -23,8 +25,6 @@ Bootstrap everything in one step:
 
 ```bash
 make tools
-# or equivalently:
-make bootstrap
 ```
 
 From this point you can use either `make <target>` or `.tool/task <target>` interchangeably.
@@ -35,7 +35,7 @@ From this point you can use either `make <target>` or `.tool/task <target>` inte
 make build
 ```
 
-This produces a local snapshot binary via [goreleaser](https://goreleaser.com). The binary ends up under `./snapshot/`.
+This produces a local snapshot binary via [goreleaser](https://goreleaser.com). The binary ends up under `./snapshot/`. goreleaser is installed automatically by `make tools` via binny — no global install needed.
 
 For a quick dev build without goreleaser:
 
@@ -75,14 +75,18 @@ Before submitting a PR, make sure `make` (the default target) passes cleanly.
 
 ```
 cmd/          Entry points (CLI wiring via cobra)
+  dive/       Main package (binary entry point)
 dive/         Core library: image analysis, file-tree diffing
   filetree/   File-tree data structures and operations
   image/      Image fetch/parsing for Docker and Podman
 internal/     Internal utilities
-runtime/      TUI, CI mode, export, and test-CLI
-  ci/         CI pass/fail evaluation logic
-  export/     JSON export
-  ui/         Terminal UI (gocui-based)
+  bus/        Event bus
+  log/        Logging
+  utils/      Shared utility helpers
+go.mod        Module definition and minimum Go version
+.goreleaser.yaml  Release build configuration
+.golangci.yaml    Linter configuration
+.github/      CI workflows
 ```
 
 ## Submitting changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,103 @@
+# Contributing to dive
+
+Thank you for your interest in contributing to dive! This document covers how to get the project building and running locally, and how to submit your changes.
+
+## Prerequisites
+
+- [Go](https://go.dev/dl/) 1.21 or later
+- [Docker](https://docs.docker.com/get-docker/) (required for integration/CLI tests)
+- `make` or `task` (see [Bootstrapping](#bootstrapping) below)
+
+## Getting the source
+
+```bash
+git clone https://github.com/wagoodman/dive.git
+cd dive
+```
+
+## Bootstrapping
+
+The project uses [task](https://taskfile.dev) as its task runner, managed by [binny](https://github.com/anchore/binny). All tools are pinned and installed locally under `.tool/` — nothing is installed system-wide.
+
+Bootstrap everything in one step:
+
+```bash
+make tools
+# or equivalently:
+make bootstrap
+```
+
+From this point you can use either `make <target>` or `.tool/task <target>` interchangeably.
+
+## Building
+
+```bash
+make build
+```
+
+This produces a local snapshot binary via [goreleaser](https://goreleaser.com). The binary ends up under `./snapshot/`.
+
+For a quick dev build without goreleaser:
+
+```bash
+go build -o dive .
+```
+
+## Running the tests
+
+```bash
+# Run all validations (static analysis + tests)
+make
+
+# Unit tests only
+make unit
+
+# CLI/integration tests only (requires Docker)
+make cli
+```
+
+## Static analysis
+
+```bash
+# Run linting and license checks
+make static-analysis
+
+# Just lint
+make lint
+
+# Check go.mod is tidy
+make check-go-mod-tidy
+```
+
+Before submitting a PR, make sure `make` (the default target) passes cleanly.
+
+## Project layout
+
+```
+cmd/          Entry points (CLI wiring via cobra)
+dive/         Core library: image analysis, file-tree diffing
+  filetree/   File-tree data structures and operations
+  image/      Image fetch/parsing for Docker and Podman
+internal/     Internal utilities
+runtime/      TUI, CI mode, export, and test-CLI
+  ci/         CI pass/fail evaluation logic
+  export/     JSON export
+  ui/         Terminal UI (gocui-based)
+```
+
+## Submitting changes
+
+1. Fork the repository and create a branch off `main`.
+2. Make your changes. Keep commits focused and the diff minimal.
+3. Run `make` and confirm everything passes.
+4. Open a pull request against `wagoodman/dive:main`. Fill in a brief description of what you changed and why, and link any relevant issues.
+
+## Code style
+
+- Follow standard Go conventions (`gofmt`, `goimports`).
+- The project uses [golangci-lint](https://golangci-lint.run/) with the configuration in `.golangci.yaml`. Running `make lint` locally will catch most issues before CI does.
+- Match the style of the surrounding code when in doubt.
+
+## License
+
+By contributing you agree that your changes will be licensed under the [Apache 2.0 License](LICENSE).


### PR DESCRIPTION
Closes wagoodman/dive#491

The project lacked any build or contribution documentation. The maintainer acknowledged this need and asked for CONTRIBUTING.md and/or DEVELOPING.md to be added (https://github.com/wagoodman/dive/issues/491#issuecomment-2724911753).

This PR adds CONTRIBUTING.md covering:
- Prerequisites
- Bootstrapping the local toolchain via `make tools`
- Building (goreleaser snapshot and plain `go build`)
- Running tests (`make unit`, `make cli`)
- Running static analysis (`make lint`, `make static-analysis`)
- Project layout overview
- How to submit a PR
- Code style notes