### PR TITLE
fix: prevent nil pointer crash when extracting with no current node

### DIFF
--- a/cmd/dive/cli/internal/ui/v1/view/filetree.go
+++ b/cmd/dive/cli/internal/ui/v1/view/filetree.go
@@ -322,6 +322,9 @@ func (v *FileTree) toggleSortOrder() error {
 
 func (v *FileTree) extractFile() error {
 	node := v.vm.CurrentNode(v.filterRegex)
+	if node == nil {
+		return nil
+	}
 	for _, listener := range v.extractListeners {
 		err := listener(node.Path())
 		if err != nil {


### PR DESCRIPTION
## What

`extractFile` (the Ctrl+E action in the file tree view) called `node.Path()` on the result of `CurrentNode(...)` without checking for `nil`. When there is no node at the current cursor position — for example when an active filter matches nothing — `CurrentNode` returns `nil` and dive segfaults:

```
panic: runtime error: invalid memory address or nil pointer dereference
github.com/wagoodman/dive/dive/filetree.(*FileNode).Path(...)
	dive/filetree/file_node.go:276
github.com/wagoodman/dive/runtime/ui/view.(*FileTree).extractFile(...)
	runtime/ui/view/filetree.go:321
```

## Fix

Guard against a `nil` node and return early, matching the existing pattern already used by the viewmodel's navigation methods (e.g. `CursorLeft`), which all bail out when `getAbsPositionNode` returns `nil`.

## Notes

Fixes #620 (reproduced and confirmed independently by another user in the issue thread). The change is a localized nil check; the affected view package has no unit tests (the views depend on a live gocui runtime), so I relied on CI for verification.